### PR TITLE
feat: add deletion confirmation in the admin dashboard

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -8,6 +8,7 @@ import { EventRecord, fetchAllEvents, WithKey } from "@/lib/firebase";
 import { classifyEventsByTiming } from "@/lib/events/classify";
 import { getEventTiming, formatEventTimeLabel, formatNextOccurrenceDate } from "@/lib/events/schedule";
 import { deleteEvent } from "@/lib/firebase/realtime";
+import { ConfirmationModal } from "@/components/ui/modal";
 
 export default function EventsManagementPage() {
 	type EventItem = WithKey<EventRecord>;
@@ -15,6 +16,8 @@ export default function EventsManagementPage() {
 	const [showModal, setShowModal] = useState(false);
 	const [showPastEvents, setShowPastEvents] = useState(false);
 	const [selectedEvent, setSelectedEvent] = useState<EventItem | null>(null);
+	const [openConfirmationModel, setOpenConfirmationModel] = useState(false);
+
 
 	const [events, setEvents] = useState<EventItem[]>([]);
 	const nowTimestamp = Date.now();
@@ -102,7 +105,7 @@ export default function EventsManagementPage() {
 								<TableCell className="max-w-[10rem] truncate">{event.location}</TableCell>
 								<TableCell className="flex justify-around gap-[15px]]">
 									<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
-									<Button variant="link" className="text-red-600" size="sm" onClick={async () => { await deleteEvent(event.id); load(); }}>Delete</Button>
+									<Button variant="link" className="text-red-600" size="sm" onClick={async () => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
 								</TableCell>
 							</TableRow>
 						))}
@@ -135,7 +138,7 @@ export default function EventsManagementPage() {
 								<TableCell className="max-w-[10rem] truncate">{event.location}</TableCell>
 								<TableCell className="flex justify-around gap-[15px]]">
 									<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
-									<Button variant="link" className="text-red-600" size="sm" onClick={async () => { await deleteEvent(event.id); load(); }}>Delete</Button>
+									<Button variant="link" className="text-red-600" size="sm" onClick={async () => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
 								</TableCell>
 							</TableRow>
 						)})}
@@ -171,7 +174,7 @@ export default function EventsManagementPage() {
 									<TableCell className="max-w-[10rem] truncate">{event.location}</TableCell>
 									<TableCell className="flex justify-around gap-[15px]]">
 										<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
-										<Button variant="link" className="text-red-600" size="sm" onClick={async () => { await deleteEvent(event.id); load(); }}>Delete</Button>
+										<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
 									</TableCell>
 								</TableRow>
 							))}
@@ -179,6 +182,23 @@ export default function EventsManagementPage() {
 					</Table>
 				)}
 			</div>
+
+			{/* Confirmation modal for deleting an event */}
+						{openConfirmationModel && 
+							<ConfirmationModal 
+								open={openConfirmationModel}
+								title="Confirm Deletion" 
+								message="Are you sure you want to delete this event? This action cannot be undone." 
+								onConfirm={async () => {
+								if (!selectedEvent?.$key) return;
+								await deleteEvent(selectedEvent.$key);
+								load();
+								}}					
+								onClose={() => setOpenConfirmationModel(false)} 
+							/>
+						}
+
+			{/* Modal for adding/editing events */}
 			{showModal && <EventModal showModal={showModal} setShowModal={setShowModal} variant={selectedEvent ? "edit" : "create"} selectedEvent={selectedEvent} onSave={() => void load()} />}
 		</div>
 	);

--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { deleteExec, ExecRecord, fetchCurrentExecs, fetchPreviousExecs, WithKey } from "@/lib/firebase";
 import ExecModal from "./execModel";
+import { ConfirmationModal } from "@/components/ui/modal";
 
 type TeamMember = WithKey<ExecRecord>;
 
@@ -47,6 +48,8 @@ export default function ExecutivesManagementPage() {
 	  const [showModal, setShowModal] = useState(false);
 	  const [selectedExec, setSelectedExec] = useState<TeamMember | null>(null);
 	  const [showPast, setShowPast] = useState(false);
+	  const [openConfirmationModel, setOpenConfirmationModel] = useState(false);
+
 	
 	  const loadTeam = async (active = true) => {
 		try {
@@ -106,7 +109,7 @@ export default function ExecutivesManagementPage() {
 									<TableCell>{exec.title}</TableCell>
 									<TableCell className="flex justify-around">
 										<Button variant="link" size="sm" onClick={() => { setSelectedExec(exec); setShowModal(true); }}>EDIT</Button>
-										<Button variant="link" className="text-red-600" size="sm" onClick={() => { deleteExec(exec.$key); loadTeam() }}>Delete</Button>
+										<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedExec(exec); setOpenConfirmationModel(true); }}>Delete</Button>
 									</TableCell>
 								</TableRow>
 							))}
@@ -140,7 +143,7 @@ export default function ExecutivesManagementPage() {
 											<TableCell>{exec.title}</TableCell>
 											<TableCell className="flex justify-around">
 												<Button variant="link" size="sm" onClick={() => { setSelectedExec(exec); setShowModal(true); }}>EDIT</Button>
-												<Button variant="link" className="text-red-600" size="sm" onClick={() => { deleteExec(exec.$key); loadTeam() }}>Delete</Button>
+												<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedExec(exec); setOpenConfirmationModel(true); }}>Delete</Button>
 											</TableCell>
 										</TableRow>
 									))}
@@ -151,6 +154,23 @@ export default function ExecutivesManagementPage() {
 					)}
 				</div>
 			</div>
+
+			{/* Confirmation modal for deleting an executive member */}
+			{openConfirmationModel && 
+				<ConfirmationModal 
+					open={openConfirmationModel}
+					title="Confirm Deletion" 
+					message="Are you sure you want to delete this executive? This action cannot be undone." 
+					onConfirm={async () => {
+					if (!selectedExec?.$key) return;
+					await deleteExec(selectedExec.$key);
+					loadTeam();
+					}}					
+					onClose={() => setOpenConfirmationModel(false)} 
+				/>
+			}
+
+			{/* Modal for adding/editing executives */}
 			{showModal && <ExecModal showModal={showModal} setShowModal={setShowModal} selectedExec={selectedExec} onSave={() => void loadTeam()} />}
 		</>
 	);

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -1,3 +1,5 @@
+import { Button } from "./button";
+
 export default function Modal({ open, onClose, title, children }: {
   open: boolean;
   onClose: () => void;
@@ -21,5 +23,36 @@ export default function Modal({ open, onClose, title, children }: {
         <>{children}</>
       </div>
     </div>
+  );
+}
+
+export function ConfirmationModal({ open, onClose, title, message, onConfirm }: {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  message: string;
+  onConfirm: () => Promise<void> | void;
+}) {
+  return (
+    <Modal open={open} onClose={onClose} title={title}>
+      <p className="mb-6 mt-[-15px]">{message}</p>
+      <div className="flex justify-end gap-4">
+        <Button
+          onClick={() => onClose()}
+          variant={"secondary"}
+        >
+          Cancel
+        </Button>
+        <Button
+          onClick={async () => {
+            await onConfirm();
+            onClose();
+          }}
+          variant={"destructive"}
+        >
+          Confirm
+        </Button>
+      </div>
+    </Modal>
   );
 }


### PR DESCRIPTION
Add confirmation before deleting an executive or event. This is what it looks like:
https://github.com/user-attachments/assets/30b7abea-ef02-4ba8-9450-e8dc146c09ae

As part of this PR, I also added a ConfirmationModal. It builds on top the pre-existing modal ui component and here is it's method signature:

```
export function ConfirmationModal({ open, onClose, title, message, onConfirm }: {
  open: boolean;
  onClose: () => void;
  title?: string;
  message: string;
  onConfirm: () => Promise<void> | void;
})
```