### PR TITLE
refactor: modularize admin dashboard tables

### DIFF
--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -9,6 +9,7 @@ import { classifyEventsByTiming } from "@/lib/events/classify";
 import { getEventTiming, formatEventTimeLabel, formatNextOccurrenceDate } from "@/lib/events/schedule";
 import { deleteEvent } from "@/lib/firebase/realtime";
 import { ConfirmationModal } from "@/components/ui/modal";
+import { AdminTable, ColumnDef } from "@/components/ui/admin-table";
 
 export default function EventsManagementPage() {
 	type EventItem = WithKey<EventRecord>;
@@ -21,6 +22,38 @@ export default function EventsManagementPage() {
 
 	const [events, setEvents] = useState<EventItem[]>([]);
 	const nowTimestamp = Date.now();
+
+	// Define shared Actions column
+	const actionsColumn: ColumnDef<typeof upcomingEvents[0]> = {
+		header: "Actions",
+		headerClassName: "text-center",
+		cellClassName: "flex justify-around gap-[15px]",
+		cell: (event) => (
+			<>
+			<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
+			<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
+			</>
+		),
+	};
+
+	// Define standard event columns (used for Upcoming & Past)
+	const standardColumns: ColumnDef<typeof upcomingEvents[0]>[] = [
+		{ header: "Event Title", accessorKey: "title", cellClassName: "max-w-[12rem] truncate" },
+		{ header: "Date", accessorKey: "date" },
+		{ header: "Time", accessorKey: "time" },
+		{ header: "Location", accessorKey: "location", cellClassName: "max-w-[10rem] truncate" },
+		actionsColumn,
+	];
+
+	// Define Recurring specific columns
+	const recurringColumns: ColumnDef<typeof recurringEvents[0]>[] = [
+		{ header: "Event Title", accessorKey: "title", cellClassName: "max-w-[12rem] truncate" },
+		{ header: "Recurrence", cell: (e) => e.rawEvent.schedule?.recurrence?.unit },
+		{ header: "Next Occurrence", cell: (e) => formatNextOccurrenceDate(getEventTiming(e.rawEvent, nowTimestamp).nextStartTimestamp) },
+		{ header: "Time", cell: (e) => formatEventTimeLabel(e.rawEvent, getEventTiming(e.rawEvent, nowTimestamp).nextStartTimestamp) },
+		{ header: "Location", accessorKey: "location", cellClassName: "max-w-[10rem] truncate" },
+		actionsColumn,
+	];
 
 	const load = async (active = true) => {
 		try {
@@ -84,68 +117,18 @@ export default function EventsManagementPage() {
 				<Button variant="primary" onClick={() => { setSelectedEvent(null); setShowModal(true); }}>+ New Event</Button>
 			</div>
 
+			{/* Upcoming Events */}
 			<div className="mb-10">
 				<h2 className="text-xl font-bold mb-4">Upcoming Events</h2>
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead>Event Title</TableHead>
-							<TableHead>Date</TableHead>
-							<TableHead>Time</TableHead>
-							<TableHead>Location</TableHead>
-							<TableHead className="text-center">Actions</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{upcomingEvents.map((event) => (
-							<TableRow key={event.id}>
-								<TableCell className="max-w-[12rem] truncate">{event.title}</TableCell>
-								<TableCell>{event.date}</TableCell>
-								<TableCell>{event.time}</TableCell>
-								<TableCell className="max-w-[10rem] truncate">{event.location}</TableCell>
-								<TableCell className="flex justify-around gap-[15px]]">
-									<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
-									<Button variant="link" className="text-red-600" size="sm" onClick={async () => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
-								</TableCell>
-							</TableRow>
-						))}
-					</TableBody>
-				</Table>
+				<AdminTable columns={standardColumns} data={upcomingEvents} keyExtractor={(e) => e.id} />
 			</div>
 
+			{/* Recurring Events */}
 			<div className="mb-10">
 				<h2 className="text-xl font-bold mb-4">Recurring Events</h2>
-				<Table>
-					<TableHeader>
-						<TableRow>
-							<TableHead>Event Title</TableHead>
-							<TableHead>Recurrence</TableHead>
-							<TableHead>Next Occurrence</TableHead>
-							<TableHead>Time</TableHead>
-							<TableHead>Location</TableHead>
-							<TableHead className="text-center">Actions</TableHead>
-						</TableRow>
-					</TableHeader>
-					<TableBody>
-						{recurringEvents.map((event) => {
-							const nextStartTimestamp = getEventTiming(event.rawEvent, nowTimestamp).nextStartTimestamp;
-							return (
-							<TableRow key={event.id}>
-								<TableCell className="max-w-[12rem] truncate">{event.title}</TableCell>
-								<TableCell>{event.rawEvent.schedule?.recurrence?.unit}</TableCell>
-								<TableCell>{formatNextOccurrenceDate(nextStartTimestamp)}</TableCell>
-								<TableCell>{formatEventTimeLabel(event.rawEvent, nextStartTimestamp)}</TableCell>
-								<TableCell className="max-w-[10rem] truncate">{event.location}</TableCell>
-								<TableCell className="flex justify-around gap-[15px]]">
-									<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
-									<Button variant="link" className="text-red-600" size="sm" onClick={async () => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
-								</TableCell>
-							</TableRow>
-						)})}
-					</TableBody>
-				</Table>
+				<AdminTable columns={recurringColumns} data={recurringEvents} keyExtractor={(e) => e.id} />
 			</div>
-
+			
 			<div className="mb-10 border-t-2 border-black pt-6">
 				<button 
 					className="flex items-center gap-2 text-xl font-bold mb-4 hover:opacity-80 transition-opacity"
@@ -155,31 +138,10 @@ export default function EventsManagementPage() {
 				</button>
 				
 				{showPastEvents && (
-					<Table>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Event Title</TableHead>
-								<TableHead>Date</TableHead>
-								<TableHead>Time</TableHead>
-								<TableHead>Location</TableHead>
-								<TableHead className="text-center">Actions</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{pastEvents.map((event) => (
-								<TableRow key={event.id}>
-									<TableCell className="max-w-[12rem] truncate">{event.title}</TableCell>
-									<TableCell>{event.date}</TableCell>
-									<TableCell>{event.time}</TableCell>
-									<TableCell className="max-w-[10rem] truncate">{event.location}</TableCell>
-									<TableCell className="flex justify-around gap-[15px]]">
-										<Button variant="link" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setShowModal(true); }}>EDIT</Button>
-										<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedEvent(event.rawEvent); setOpenConfirmationModel(true); }}>Delete</Button>
-									</TableCell>
-								</TableRow>
-							))}
-						</TableBody>
-					</Table>
+					<div className="mb-10">
+						<h2 className="text-xl font-bold mb-4">Past Events</h2>
+						<AdminTable columns={standardColumns} data={pastEvents} keyExtractor={(e) => e.id} />
+					</div>
 				)}
 			</div>
 

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import EventModal from "./eventsModel";
 import { useEffect, useMemo, useState } from "react";

--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
-import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { deleteExec, ExecRecord, fetchCurrentExecs, fetchPreviousExecs, WithKey } from "@/lib/firebase";
 import ExecModal from "./execModel";
 import { ConfirmationModal } from "@/components/ui/modal";

--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -7,7 +7,6 @@ import { deleteExec, ExecRecord, fetchCurrentExecs, fetchPreviousExecs, WithKey 
 import ExecModal from "./execModel";
 import { ConfirmationModal } from "@/components/ui/modal";
 import { AdminTable, ColumnDef } from "@/components/ui/admin-table";
-import { exec } from "child_process";
 
 type TeamMember = WithKey<ExecRecord>;
 

--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -6,6 +6,8 @@ import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@
 import { deleteExec, ExecRecord, fetchCurrentExecs, fetchPreviousExecs, WithKey } from "@/lib/firebase";
 import ExecModal from "./execModel";
 import { ConfirmationModal } from "@/components/ui/modal";
+import { AdminTable, ColumnDef } from "@/components/ui/admin-table";
+import { exec } from "child_process";
 
 type TeamMember = WithKey<ExecRecord>;
 
@@ -49,6 +51,25 @@ export default function ExecutivesManagementPage() {
 	  const [selectedExec, setSelectedExec] = useState<TeamMember | null>(null);
 	  const [showPast, setShowPast] = useState(false);
 	  const [openConfirmationModel, setOpenConfirmationModel] = useState(false);
+
+		// Define shared Actions column
+		const actionsColumn: ColumnDef<typeof currentExecs[0]> = {
+			header: "Actions",
+			headerClassName: "text-center",
+			cellClassName: "flex justify-around gap-[15px]",
+			cell: (event) => (
+				<>
+					<Button variant="link" size="sm" onClick={() => { setSelectedExec(event); setShowModal(true); }}>EDIT</Button>
+					<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedExec(event); setOpenConfirmationModel(true); }}>Delete</Button>
+				</>
+			),
+		};
+
+		const standardColumns: ColumnDef<typeof currentExecs[0]>[] = [
+			{ header: "Name", accessorKey: "name", cellClassName: "max-w-[12rem] truncate" },
+			{ header: "Role", accessorKey: "title" },
+			actionsColumn,
+		];
 
 	
 	  const loadTeam = async (active = true) => {
@@ -94,27 +115,7 @@ export default function ExecutivesManagementPage() {
 
 				<div className="mb-10">
 					<h2 className="text-lg font-bold mb-4">Current Executive</h2>
-					<Table>
-						<TableHeader>
-							<TableRow>
-								<TableHead>Name</TableHead>
-								<TableHead>Role</TableHead>
-								<TableHead className="text-center">Action</TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{currentExecs.map((exec, idx) => (
-								<TableRow key={idx}>
-									<TableCell>{exec.name}</TableCell>
-									<TableCell>{exec.title}</TableCell>
-									<TableCell className="flex justify-around">
-										<Button variant="link" size="sm" onClick={() => { setSelectedExec(exec); setShowModal(true); }}>EDIT</Button>
-										<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedExec(exec); setOpenConfirmationModel(true); }}>Delete</Button>
-									</TableCell>
-								</TableRow>
-							))}
-						</TableBody>
-					</Table>
+					<AdminTable columns={standardColumns} data={currentExecs} keyExtractor={(e) => e.$key} />
 					<div className="mt-2 text-right text-xs text-neutral-500 font-semibold">{currentExecs.length} active members</div>
 				</div>
 
@@ -128,27 +129,7 @@ export default function ExecutivesManagementPage() {
 					{showPast && (
 						<div className="mt-4">
 							<h2 className="text-lg font-bold mb-4">Past Executives</h2>
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead>Name</TableHead>
-										<TableHead>Role</TableHead>
-										<TableHead className="text-center">Action</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{previousExecs.map((exec, idx) => (
-										<TableRow key={idx}>
-											<TableCell>{exec.name}</TableCell>
-											<TableCell>{exec.title}</TableCell>
-											<TableCell className="flex justify-around">
-												<Button variant="link" size="sm" onClick={() => { setSelectedExec(exec); setShowModal(true); }}>EDIT</Button>
-												<Button variant="link" className="text-red-600" size="sm" onClick={() => { setSelectedExec(exec); setOpenConfirmationModel(true); }}>Delete</Button>
-											</TableCell>
-										</TableRow>
-									))}
-								</TableBody>
-							</Table>
+							<AdminTable columns={standardColumns} data={previousExecs} keyExtractor={(e) => e.$key} />
 							<div className="mt-2 text-right text-xs text-neutral-500 font-semibold">{previousExecs.length} past members</div>
 						</div>
 					)}

--- a/components/ui/admin-table.tsx
+++ b/components/ui/admin-table.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react";
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
+
+// Defines how each column should render its header and cell
+export interface ColumnDef<T> {
+  header: ReactNode;
+  accessorKey?: keyof T;
+  cell?: (item: T) => ReactNode;
+  headerClassName?: string;
+  cellClassName?: string;
+}
+
+interface AdminTableProps<T> {
+  columns: ColumnDef<T>[];
+  data: T[];
+  keyExtractor: (item: T) => string | number;
+}
+
+export function AdminTable<T>({ columns, data, keyExtractor }: AdminTableProps<T>) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          {columns.map((col, idx) => (
+            <TableHead key={idx} className={col.headerClassName}>
+              {col.header}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {data.map((item) => (
+          <TableRow key={keyExtractor(item)}>
+            {columns.map((col, idx) => (
+              <TableCell key={idx} className={col.cellClassName}>
+                {col.cell ? col.cell(item) : col.accessorKey ? String(item[col.accessorKey]) : null}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/components/ui/admin-table.tsx
+++ b/components/ui/admin-table.tsx
@@ -33,7 +33,11 @@ export function AdminTable<T>({ columns, data, keyExtractor }: AdminTableProps<T
           <TableRow key={keyExtractor(item)}>
             {columns.map((col, idx) => (
               <TableCell key={idx} className={col.cellClassName}>
-                {col.cell ? col.cell(item) : col.accessorKey ? String(item[col.accessorKey]) : null}
+                {col.cell
+                  ? col.cell(item) 
+                  : col.accessorKey && item[col.accessorKey] != null 
+                    ? String(item[col.accessorKey]) 
+                    : ""}
               </TableCell>
             ))}
           </TableRow>


### PR DESCRIPTION
The admin panel had a lot of repeated table code across pages (upcoming, recurring, past events, etc.), which made updates tedious and error-prone.

This PR introduces a reusable AdminTable UI component and refactors existing admin pages to use it. Now, any table-related changes can be made in one place instead of updating multiple files.