### PR TITLE
Bring back instant cleanup when a branch is deleted

### DIFF
--- a/.github/scripts/komodo.sh
+++ b/.github/scripts/komodo.sh
@@ -3,16 +3,22 @@
 # exported by the calling step, and needs jq + curl on PATH.
 
 # POST $1=path $2=json body. Prints the response body on success. On HTTP
-# >= 400, prints the real status + response body via ::error:: and returns
-# non-zero, instead of curl -sf's bare, contextless exit code.
+# >= 400, prints the real status + response body and returns non-zero,
+# instead of curl -sf's bare, contextless exit code. Pass $3=quiet to
+# suppress the ::error:: annotation for calls where failure is expected
+# and handled by the caller (e.g. probing whether something exists).
 komodo() {
-  local path="$1" body="$2" resp status
+  local path="$1" body="$2" quiet="${3:-}" resp status
   resp="$(mktemp)"
   status=$(curl -s -o "$resp" -w '%{http_code}' -X POST "$KOMODO_HOST$path" \
     -H "Content-Type: application/json" -H "x-api-key: $KOMODO_API_KEY" -H "x-api-secret: $KOMODO_API_SECRET" \
     -d "$body")
   if [ "$status" -ge 400 ]; then
-    echo "::error::POST $path -> HTTP $status: $(cat "$resp")"
+    if [ "$quiet" = "quiet" ]; then
+      echo "POST $path -> HTTP $status: $(cat "$resp")"
+    else
+      echo "::error::POST $path -> HTTP $status: $(cat "$resp")"
+    fi
     rm -f "$resp"
     return 1
   fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["**"]
     tags: ["v*"]
+  delete:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -11,6 +12,7 @@ concurrency:
 
 jobs:
   checks:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -115,3 +117,41 @@ jobs:
           script-path: komodo/actions/preview-sweep.ts
           schedule: "at 09:00 am"
           schedule-enabled: true
+
+  cleanup:
+    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && github.event.ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: ctx
+        env:
+          BRANCH: ${{ github.event.ref }}
+        run: |
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
+          echo "stack_name=brockcsc-pr-$SLUG" >> "$GITHUB_OUTPUT"
+          echo "db_schema=preview_${SLUG//-/_}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete Komodo stack
+        env:
+          KOMODO_HOST: ${{ vars.KOMODO_HOST }}
+          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
+          KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+        run: |
+          source .github/scripts/komodo.sh
+          komodo /write "$(jq -n --arg id "${{ steps.ctx.outputs.stack_name }}" '{type:"DeleteStack", params:{id:$id}}')" \
+            || echo "::warning::DeleteStack failed (stack may not exist) - continuing, the daily sweep will catch it"
+
+      - name: Drop preview schema
+        env:
+          SSH_KEY: ${{ secrets.BROCKCSC_DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ vars.BROCKCSC_DEPLOY_HOST }}
+          DEPLOY_USER: ${{ vars.BROCKCSC_DEPLOY_USER }}
+          DB_SCHEMA: ${{ steps.ctx.outputs.db_schema }}
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_deploy
+          echo "$SSH_KEY" > ~/.ssh/id_deploy
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/id_deploy "$DEPLOY_USER@$DEPLOY_HOST" \
+            "docker exec postgres psql -U brockcsc -d brockcsc -c \"DROP SCHEMA IF EXISTS $DB_SCHEMA CASCADE;\"" \
+            || echo "::warning::Schema drop failed - continuing, the daily sweep will catch it"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,47 @@
+name: Cleanup
+
+on:
+  delete:
+
+concurrency:
+  group: cleanup-${{ github.event.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    if: github.event.ref_type == 'branch' && github.event.ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: ctx
+        env:
+          BRANCH: ${{ github.event.ref }}
+        run: |
+          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
+          echo "stack_name=brockcsc-pr-$SLUG" >> "$GITHUB_OUTPUT"
+          echo "db_schema=preview_${SLUG//-/_}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete Komodo stack
+        env:
+          KOMODO_HOST: ${{ vars.KOMODO_HOST }}
+          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
+          KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+        run: |
+          source .github/scripts/komodo.sh
+          komodo /write "$(jq -n --arg id "${{ steps.ctx.outputs.stack_name }}" '{type:"DeleteStack", params:{id:$id}}')" \
+            || echo "::warning::DeleteStack failed (stack may not exist) - continuing, the daily sweep will catch it"
+
+      - name: Drop preview schema
+        env:
+          SSH_KEY: ${{ secrets.BROCKCSC_DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ vars.BROCKCSC_DEPLOY_HOST }}
+          DEPLOY_USER: ${{ vars.BROCKCSC_DEPLOY_USER }}
+          DB_SCHEMA: ${{ steps.ctx.outputs.db_schema }}
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_deploy
+          echo "$SSH_KEY" > ~/.ssh/id_deploy
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/id_deploy "$DEPLOY_USER@$DEPLOY_HOST" \
+            "docker exec postgres psql -U brockcsc -d brockcsc -c \"DROP SCHEMA IF EXISTS $DB_SCHEMA CASCADE;\"" \
+            || echo "::warning::Schema drop failed - continuing, the daily sweep will catch it"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,20 @@
-name: CI
+name: Build & Deploy
 
 on:
   push:
     branches: ["**"]
     tags: ["v*"]
-  delete:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   checks:
-    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -54,8 +52,8 @@ jobs:
       name: ${{ needs.context.outputs.env_name }}
       url: ${{ needs.context.outputs.url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 
@@ -72,12 +70,15 @@ jobs:
         run: |
           source .github/scripts/komodo.sh
 
-          # Creating an already-existing Variable 4xxs on every run after the
-          # first - expected, so this only warns rather than failing the step.
           sync_var() {
-            komodo /write "$(jq -n --arg name "$1" --arg value "$2" --argjson is_secret "$3" \
-              '{type:"CreateVariable", params:{name:$name, value:$value, is_secret:$is_secret}}')" \
-              || echo "::warning::CreateVariable $1 failed (likely already exists, see error above) - continuing"
+            local name="$1" value="$2" is_secret="$3"
+            if komodo /read "$(jq -n --arg name "$name" '{type:"GetVariable", params:{name:$name}}')" quiet >/dev/null; then
+              komodo /write "$(jq -n --arg name "$name" --arg value "$value" \
+                '{type:"UpdateVariableValue", params:{name:$name, value:$value}}')" >/dev/null
+            else
+              komodo /write "$(jq -n --arg name "$name" --arg value "$value" --argjson is_secret "$is_secret" \
+                '{type:"CreateVariable", params:{name:$name, value:$value, is_secret:$is_secret}}')" >/dev/null
+            fi
           }
 
           sync_var BROCKCSC_DB_PASSWORD "$VAL_BROCKCSC_DB_PASSWORD" true
@@ -117,41 +118,3 @@ jobs:
           script-path: komodo/actions/preview-sweep.ts
           schedule: "at 09:00 am"
           schedule-enabled: true
-
-  cleanup:
-    if: github.event_name == 'delete' && github.event.ref_type == 'branch' && github.event.ref != 'main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: ctx
-        env:
-          BRANCH: ${{ github.event.ref }}
-        run: |
-          SLUG=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
-          echo "stack_name=brockcsc-pr-$SLUG" >> "$GITHUB_OUTPUT"
-          echo "db_schema=preview_${SLUG//-/_}" >> "$GITHUB_OUTPUT"
-
-      - name: Delete Komodo stack
-        env:
-          KOMODO_HOST: ${{ vars.KOMODO_HOST }}
-          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
-          KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
-        run: |
-          source .github/scripts/komodo.sh
-          komodo /write "$(jq -n --arg id "${{ steps.ctx.outputs.stack_name }}" '{type:"DeleteStack", params:{id:$id}}')" \
-            || echo "::warning::DeleteStack failed (stack may not exist) - continuing, the daily sweep will catch it"
-
-      - name: Drop preview schema
-        env:
-          SSH_KEY: ${{ secrets.BROCKCSC_DEPLOY_SSH_KEY }}
-          DEPLOY_HOST: ${{ vars.BROCKCSC_DEPLOY_HOST }}
-          DEPLOY_USER: ${{ vars.BROCKCSC_DEPLOY_USER }}
-          DB_SCHEMA: ${{ steps.ctx.outputs.db_schema }}
-        run: |
-          install -m 600 -D /dev/null ~/.ssh/id_deploy
-          echo "$SSH_KEY" > ~/.ssh/id_deploy
-          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          ssh -i ~/.ssh/id_deploy "$DEPLOY_USER@$DEPLOY_HOST" \
-            "docker exec postgres psql -U brockcsc -d brockcsc -c \"DROP SCHEMA IF EXISTS $DB_SCHEMA CASCADE;\"" \
-            || echo "::warning::Schema drop failed - continuing, the daily sweep will catch it"

--- a/components/sections/about-us.tsx
+++ b/components/sections/about-us.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import { Users, FileText, User } from "lucide-react";
 import { InfoCardButton } from "@/components/ui/info-card-button";
 import { fetchCurrentExecs, type ExecRecord, type WithKey } from "@/lib/api";
@@ -71,12 +72,14 @@ export function AboutUsSection() {
                 key={exec.$key}
                 className="relative group flex justify-center"
               >
-                <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-full border-[3px] border-black bg-neutral-100 flex items-center justify-center overflow-hidden shadow-[3px_3px_0_0_#9A4440] transition-transform group-hover:-translate-y-1 duration-300">
+                <div className="relative w-16 h-16 sm:w-20 sm:h-20 rounded-full border-[3px] border-black bg-neutral-100 flex items-center justify-center overflow-hidden shadow-[3px_3px_0_0_#9A4440] transition-transform group-hover:-translate-y-1 duration-300">
                   {exec.image?.url ? (
-                    <img
+                    <Image
                       src={exec.image.url}
                       alt={exec.name || "Exec Member"}
-                      className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
+                      fill
+                      unoptimized
+                      className="object-cover transition-transform duration-300 group-hover:scale-110"
                     />
                   ) : (
                     <User

--- a/components/ui/event-card.tsx
+++ b/components/ui/event-card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { ArrowUpRight } from "lucide-react";
 
@@ -25,16 +26,20 @@ export function EventCard({
       >
         {imageUrl ? (
           <>
-            <img
+            <Image
               src={imageUrl}
               alt=""
               aria-hidden="true"
-              className="absolute inset-0 w-full h-full object-cover blur-xl opacity-40 scale-110 pointer-events-none transition-transform duration-500 group-hover/card:scale-125"
+              fill
+              unoptimized
+              className="object-cover blur-xl opacity-40 scale-110 pointer-events-none transition-transform duration-500 group-hover/card:scale-125"
             />
-            <img
+            <Image
               src={imageUrl}
               alt={title}
-              className="relative z-10 w-full h-full object-contain transition-transform duration-500 group-hover/card:scale-105"
+              fill
+              unoptimized
+              className="z-10 object-contain transition-transform duration-500 group-hover/card:scale-105"
             />
           </>
         ) : (

--- a/components/ui/photo-frame.tsx
+++ b/components/ui/photo-frame.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 interface PhotoFrameProps {
@@ -17,13 +18,15 @@ export function PhotoFrame({
     <div className={cn("relative w-full h-full", className)}>
       <div className="absolute inset-0 rounded-[32px] border-[3px] border-black bg-white rotate-2 shadow-[8px_8px_0_0_#9A4440] z-10 transition-transform hover:rotate-1 duration-500 overflow-hidden group">
         <div className="w-full h-full bg-neutral-100 flex items-center justify-center p-2">
-          <div className="w-full h-full rounded-[24px] overflow-hidden">
+          <div className="relative w-full h-full rounded-[24px] overflow-hidden">
             {children ||
               (src ? (
-                <img
+                <Image
                   src={src}
                   alt={alt}
-                  className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-700"
+                  fill
+                  unoptimized
+                  className="object-cover group-hover:scale-105 transition-transform duration-700"
                 />
               ) : (
                 <span className="text-neutral-400 font-bold text-xl uppercase tracking-widest flex w-full h-full items-center justify-center group-hover:scale-105 transition-transform duration-700">


### PR DESCRIPTION
## What this does

When you delete a branch, its preview site and test database now get cleaned up right away, instead of waiting for the once-a-day cleanup that runs at 9am.

This is the same instant cleanup we used to have before the recent CI/CD rewrite — it got dropped by accident during that change. The daily cleanup still runs too, as a backup in case the instant one ever fails.

While wiring this up, split the workflow so cleanup isn't chained onto the CI workflow (it isn't CI):

- `.github/workflows/ci.yml` → `deploy.yml` (checks/context/deploy on push) + `cleanup.yml` (delete-triggered stack/schema teardown)
- Bumped `actions/checkout`/`actions/setup-node` to v5 to drop the Node 20 deprecation warning
- Komodo variable sync now checks whether a variable exists before deciding Create vs UpdateVariableValue, instead of always trying Create and logging an expected error/warning pair on every run after the first
- Swapped `<img>` for `next/image` (`fill` + `unoptimized`, matching the existing pattern in `team-member-card.tsx`) in `photo-frame.tsx`, `event-card.tsx`, and `about-us.tsx` to clear the `no-img-element` lint warning

## Testing

Lint, typecheck, and format:check pass locally. CI checks running on this PR.