### PR TITLE
Sync uat/dev schemas from prod on every deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules/drizzle-orm ./node_m
 
 USER nextjs
 EXPOSE 3000
-CMD ["sh", "-c", "node scripts/migrate.mjs && node server.js"]
+CMD ["sh", "-c", "node scripts/migrate.mjs && node scripts/sync-from-prod.mjs && node server.js"]

--- a/scripts/sync-from-prod.mjs
+++ b/scripts/sync-from-prod.mjs
@@ -1,0 +1,38 @@
+import { Pool } from "pg";
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL env var is not set.");
+}
+
+const schema = process.env.DB_SCHEMA ?? "public";
+if (!/^[a-z0-9_]+$/.test(schema)) {
+  throw new Error(`Invalid DB_SCHEMA: ${schema}`);
+}
+
+if (schema === "prod") {
+  console.log("DB_SCHEMA is prod; skipping sync-from-prod.");
+  process.exit(0);
+}
+
+const pool = new Pool({ connectionString });
+
+const prodSchemaExists = await pool.query(
+  `SELECT 1 FROM information_schema.schemata WHERE schema_name = 'prod'`,
+);
+if (prodSchemaExists.rowCount === 0) {
+  console.log("prod schema does not exist yet; skipping sync-from-prod.");
+  await pool.end();
+  process.exit(0);
+}
+
+for (const table of ["events", "execs"]) {
+  await pool.query(`TRUNCATE TABLE "${schema}"."${table}"`);
+  await pool.query(
+    `INSERT INTO "${schema}"."${table}" SELECT * FROM "prod"."${table}"`,
+  );
+}
+
+await pool.end();
+
+console.log(`Synced schema "${schema}" from prod.`);


### PR DESCRIPTION
## What this does

Adds `scripts/sync-from-prod.mjs` to the container boot sequence (`migrate.mjs && sync-from-prod.mjs && server.js`). On every deploy of a non-prod environment (uat or a branch preview), its `execs`/`events` tables are truncated and replaced with a copy of whatever's currently in `prod` — no-op if `prod`'s schema doesn't exist yet.

Previously uat and preview branches started empty; now they mirror prod's real content automatically, so testing/reviewing against them actually looks like the site.

`prod` and `uat` were also seeded directly (execs + events scraped from the legacy brockcsc.ca site) via a one-time SQL run against the VPS — that's already live in the DB, this PR is just the ongoing sync mechanism.

## Testing

Lint, typecheck, and format:check pass locally.