### PR TITLE
Group past execs by term on the team page

### DIFF
--- a/app/admin/execs/exec-modal.tsx
+++ b/app/admin/execs/exec-modal.tsx
@@ -24,6 +24,7 @@ export default function ExecModal({
   const [isPast, setIsPast] = useState(
     selectedExec ? !(selectedExec.isCurrentExec ?? true) : false,
   );
+  const [term, setTerm] = useState(selectedExec?.term ?? "");
   const [github, setGithub] = useState(selectedExec?.socials?.github ?? "");
   const [linkedin, setLinkedin] = useState(
     selectedExec?.socials?.linkedin ?? "",
@@ -46,6 +47,7 @@ export default function ExecModal({
         description,
         title,
         isCurrentExec: !isPast,
+        term: isPast ? term : "",
         image: { url: photoUrl },
         socials: { github, linkedin, instagram, x: twitter },
       };
@@ -127,6 +129,20 @@ export default function ExecModal({
             </select>
           </div>
         </div>
+        {isPast && (
+          <div className="mb-4">
+            <label className="block text-sm font-semibold mb-1">
+              Term (e.g. 2016-2017)
+            </label>
+            <input
+              type="text"
+              className="w-full rounded border px-3 py-2"
+              placeholder="2016-2017"
+              value={term}
+              onChange={(e) => setTerm(e.target.value)}
+            />
+          </div>
+        )}
         <div className="mb-4">
           <label className="block text-sm font-semibold mb-1">Github URL</label>
           <input

--- a/app/team/pageClient.tsx
+++ b/app/team/pageClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   fetchCurrentExecs,
@@ -13,6 +13,34 @@ import { sortCurrentExecsByRoleThenDatabaseOrder } from "@/lib/execs/order";
 import { TeamMemberCard } from "./components/team-member-card";
 
 type TeamMember = WithKey<ExecRecord>;
+
+const UNDATED_TERM = "Previous Executives";
+
+const groupPreviousExecsByTerm = (
+  execs: TeamMember[],
+): { term: string; members: TeamMember[] }[] => {
+  const groups = new Map<string, TeamMember[]>();
+
+  for (const member of execs) {
+    const term = member.term?.trim() || UNDATED_TERM;
+    const existing = groups.get(term);
+    if (existing) {
+      existing.push(member);
+    } else {
+      groups.set(term, [member]);
+    }
+  }
+
+  const dated = Array.from(groups.entries())
+    .filter(([term]) => term !== UNDATED_TERM)
+    .sort(([a], [b]) => b.localeCompare(a));
+  const undated = groups.get(UNDATED_TERM);
+
+  return [
+    ...dated.map(([term, members]) => ({ term, members })),
+    ...(undated ? [{ term: UNDATED_TERM, members: undated }] : []),
+  ];
+};
 
 export default function TeamPageClient() {
   const [currentExecs, setCurrentExecs] = useState<TeamMember[]>([]);
@@ -60,6 +88,10 @@ export default function TeamPageClient() {
 
   const hasCurrentExecs = currentExecs.length > 0;
   const hasPreviousExecs = previousExecs.length > 0;
+  const previousExecGroups = useMemo(
+    () => groupPreviousExecsByTerm(previousExecs),
+    [previousExecs],
+  );
   const errorMessage = error ? (
     <p className="mb-4 text-muted-foreground">{error}</p>
   ) : null;
@@ -120,9 +152,22 @@ export default function TeamPageClient() {
         )}
 
         {hasPreviousExecs && (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
-            {previousExecs.map((member) => (
-              <TeamMemberCard isAlumni key={member.$key} member={member} />
+          <div className="flex flex-col gap-4">
+            {previousExecGroups.map((group) => (
+              <section key={group.term}>
+                <h3 className="mb-2 text-base font-semibold text-foreground/80">
+                  {group.term}
+                </h3>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5">
+                  {group.members.map((member) => (
+                    <TeamMemberCard
+                      isAlumni
+                      key={member.$key}
+                      member={member}
+                    />
+                  ))}
+                </div>
+              </section>
             ))}
           </div>
         )}

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -19,6 +19,7 @@ export type ExecRecord = {
   title?: string;
   description?: string;
   isCurrentExec?: boolean;
+  term?: string;
   socials?: ExecSocialLinks;
   image?: {
     url?: string;


### PR DESCRIPTION
## What this does

Adds an optional `term` field to execs (e.g. `2016-2017`), editable in the admin panel when "Past Executive" is checked. The team page now groups past execs into dated sections by term, same pattern as the events page's Fall/Winter/Spring groupings — anyone without a term falls into a single "Previous Executives" bucket at the end, matching what the old site did for everyone.

`term` was set directly in prod/uat for the 5 alumni who already stated their own term in their bio text on the club's public site (e.g. "President 2016-2017") — that's self-reported, first-party data, not looked up. Everyone else stays undated for now rather than guessing.

## Testing

Lint, typecheck, and format:check pass locally.