### PR TITLE
Sort alumni by term year and role

### DIFF
--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -9,7 +9,7 @@ import {
   fetchPreviousExecs,
   WithKey,
 } from "@/lib/api";
-import { sortCurrentExecsByRoleThenDatabaseOrder } from "@/lib/execs/order";
+import { sortExecsByRoleThenDatabaseOrder } from "@/lib/execs/order";
 import ExecModal from "./exec-modal";
 import { ConfirmationModal } from "@/components/ui/modal";
 import { AdminTable, ColumnDef } from "@/components/ui/admin-table";
@@ -76,7 +76,7 @@ export default function ExecutivesManagementPage() {
         return;
       }
 
-      setCurrentExecs(sortCurrentExecsByRoleThenDatabaseOrder(current));
+      setCurrentExecs(sortExecsByRoleThenDatabaseOrder(current));
       setPreviousExecs(previous);
     } catch {
       if (!isActive()) {

--- a/app/team/pageClient.tsx
+++ b/app/team/pageClient.tsx
@@ -8,7 +8,10 @@ import {
   type ExecRecord,
   type WithKey,
 } from "@/lib/api";
-import { sortCurrentExecsByRoleThenDatabaseOrder } from "@/lib/execs/order";
+import {
+  sortExecsByRoleThenDatabaseOrder,
+  termStartYear,
+} from "@/lib/execs/order";
 
 import { TeamMemberCard } from "./components/team-member-card";
 
@@ -33,13 +36,17 @@ const groupPreviousExecsByTerm = (
 
   const dated = Array.from(groups.entries())
     .filter(([term]) => term !== UNDATED_TERM)
-    .sort(([a], [b]) => b.localeCompare(a));
+    .sort(
+      ([a], [b]) => termStartYear(b) - termStartYear(a) || b.localeCompare(a),
+    );
   const undated = groups.get(UNDATED_TERM);
 
-  return [
-    ...dated.map(([term, members]) => ({ term, members })),
-    ...(undated ? [{ term: UNDATED_TERM, members: undated }] : []),
-  ];
+  return [...dated, ...(undated ? [[UNDATED_TERM, undated] as const] : [])].map(
+    ([term, members]) => ({
+      term,
+      members: sortExecsByRoleThenDatabaseOrder(members),
+    }),
+  );
 };
 
 export default function TeamPageClient() {
@@ -65,7 +72,7 @@ export default function TeamPageClient() {
           return;
         }
 
-        setCurrentExecs(sortCurrentExecsByRoleThenDatabaseOrder(current));
+        setCurrentExecs(sortExecsByRoleThenDatabaseOrder(current));
         setPreviousExecs(previous);
       } catch {
         if (!active) {

--- a/lib/execs/order.ts
+++ b/lib/execs/order.ts
@@ -6,8 +6,8 @@ const UNKNOWN_ROLE_PRIORITY = Number.MAX_SAFE_INTEGER;
 
 const ROLE_PRIORITY: Record<string, number> = {
   president: 1,
-  "vice president": 2,
-  "co-president": 3,
+  "co-president": 2,
+  "vice president": 3,
   treasurer: 4,
   executive: 5,
 };
@@ -17,7 +17,11 @@ const getRolePriority = (title?: string): number => {
   return ROLE_PRIORITY[normalizedTitle] ?? UNKNOWN_ROLE_PRIORITY;
 };
 
-export const sortCurrentExecsByRoleThenDatabaseOrder = (
+/** Leading year of a term like "2016-2017", or -1 when there isn't one. */
+export const termStartYear = (term: string): number =>
+  Number(term.match(/\d{4}/)?.[0] ?? -1);
+
+export const sortExecsByRoleThenDatabaseOrder = (
   members: TeamMember[],
 ): TeamMember[] => {
   const orderByKey = new Map<string, number>();


### PR DESCRIPTION
- Group alumni terms by parsed start year instead of raw string compare
- Role-sort execs within each alumni group, matching the current-execs grid
- Rank co-president above vice president