### PR TITLE
Sign-up approval queue

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -10,6 +10,7 @@ const adminTabs = [
   { name: "Dashboard", href: "/admin" },
   { name: "Events Management", href: "/admin/events" },
   { name: "Executives Management", href: "/admin/execs" },
+  { name: "Sign-up Requests", href: "/admin/signups" },
 ];
 
 export default function AdminLayout({

--- a/app/admin/signups/page.tsx
+++ b/app/admin/signups/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  fetchInviteCode,
+  fetchSignups,
+  reviewSignup,
+  SignupRecord,
+  WithKey,
+} from "@/lib/api";
+import { AdminTable, ColumnDef } from "@/components/ui/admin-table";
+import { Button } from "@/components/ui/button";
+import { ConfirmationModal } from "@/components/ui/modal";
+
+type Signup = WithKey<SignupRecord>;
+
+const humanise = (ms: number): string => {
+  const units = [
+    ["day", 86_400_000],
+    ["hour", 3_600_000],
+    ["minute", 60_000],
+  ] as const;
+  for (const [name, size] of units) {
+    const count = Math.floor(ms / size);
+    if (count >= 1) return `${count} ${name}${count === 1 ? "" : "s"}`;
+  }
+  return "under a minute";
+};
+
+const fullName = (signup: Signup) =>
+  [signup.firstName, signup.lastName].filter(Boolean).join(" ");
+
+const submittedOn = (signup: Signup) =>
+  signup.submittedAt ? new Date(signup.submittedAt).toLocaleDateString() : "—";
+
+export default function SignupRequestsPage() {
+  const [signups, setSignups] = useState<Signup[]>([]);
+  const [invite, setInvite] = useState<{
+    code: string;
+    expiresInMs: number;
+  } | null>(null);
+  const [rejecting, setRejecting] = useState<Signup | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      setSignups(await fetchSignups());
+    } catch {
+      setError("Could not load sign-up requests right now.");
+    }
+  };
+
+  useEffect(() => {
+    void (async () => {
+      await load();
+    })();
+    void fetchInviteCode()
+      .then(setInvite)
+      .catch(() => setInvite(null));
+  }, []);
+
+  const review = async (signup: Signup, action: "approve" | "reject") => {
+    setError(null);
+    try {
+      await reviewSignup(signup.$key, action);
+      await load();
+    } catch {
+      setError(`Could not ${action} ${fullName(signup)}. Please try again.`);
+    }
+  };
+
+  const details: ColumnDef<Signup>[] = [
+    { header: "Name", cell: fullName },
+    { header: "Username", accessorKey: "username" },
+    { header: "Email", accessorKey: "email" },
+    { header: "Phone", accessorKey: "phone" },
+    { header: "Submitted", cell: submittedOn },
+  ];
+
+  const pendingColumns: ColumnDef<Signup>[] = [
+    ...details,
+    {
+      header: "Actions",
+      headerClassName: "text-center",
+      cellClassName: "flex justify-around gap-[15px]",
+      cell: (signup) => (
+        <>
+          <Button size="xs" onClick={() => review(signup, "approve")}>
+            Approve
+          </Button>
+          <Button
+            size="xs"
+            variant="destructive"
+            onClick={() => setRejecting(signup)}
+          >
+            Reject
+          </Button>
+        </>
+      ),
+    },
+  ];
+
+  const processedColumns: ColumnDef<Signup>[] = [
+    ...details,
+    { header: "Status", accessorKey: "status" },
+    { header: "Reviewed by", accessorKey: "reviewedBy" },
+  ];
+
+  const pending = signups.filter((signup) => signup.status === "pending");
+  const processed = signups.filter((signup) => signup.status !== "pending");
+
+  return (
+    <>
+      <div>
+        <h1 className="text-2xl font-bold mb-2">Sign-up Requests</h1>
+        <p className="text-neutral-500 mb-6">
+          Review executive sign-ups. Approving enables the account; rejecting
+          deletes it.
+        </p>
+
+        <div className="mb-8 rounded-2xl border-2 border-black bg-[#fff1f0] shadow-[4px_4px_0px_#9A4440] p-6">
+          <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Current invite code
+          </div>
+          <div className="text-3xl font-bold tracking-[0.2em] text-[#9A4440] my-1">
+            {invite?.code ?? "————————"}
+          </div>
+          <div className="text-sm text-neutral-600">
+            {invite
+              ? `Rotates in ${humanise(invite.expiresInMs)}`
+              : "Unavailable"}
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-[12px] border-2 border-[#d44b4b] px-4 py-2 font-semibold text-[#d44b4b]">
+            {error}
+          </div>
+        )}
+
+        <div className="mb-10">
+          <h2 className="text-lg font-bold mb-4">Pending</h2>
+          <AdminTable
+            columns={pendingColumns}
+            data={pending}
+            keyExtractor={(s) => s.$key}
+          />
+          <div className="mt-2 text-right text-xs text-neutral-500 font-semibold">
+            {pending.length} awaiting review
+          </div>
+        </div>
+
+        <div className="mb-10 border-t-2 border-black pt-6">
+          <h2 className="text-lg font-bold mb-4">Processed</h2>
+          <AdminTable
+            columns={processedColumns}
+            data={processed}
+            keyExtractor={(s) => s.$key}
+          />
+        </div>
+      </div>
+
+      {rejecting && (
+        <ConfirmationModal
+          open={!!rejecting}
+          title="Confirm Rejection"
+          message={`Rejecting ${fullName(rejecting)} permanently deletes their Keycloak account. This cannot be undone.`}
+          onConfirm={() => review(rejecting, "reject")}
+          onClose={() => setRejecting(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/app/api/invite-code/route.ts
+++ b/app/api/invite-code/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { currentInviteCode, inviteCodeExpiresIn } from "@/lib/auth/invite-code";
+import { requireAdmin } from "@/lib/auth/session";
+
+export const GET = (req: NextRequest) => {
+  if (!requireAdmin(req)) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+  return NextResponse.json({
+    code: currentInviteCode(),
+    expiresInMs: inviteCodeExpiresIn(),
+  });
+};

--- a/app/api/signups/[id]/route.ts
+++ b/app/api/signups/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { SignupRecord } from "@/lib/api/types";
+import {
+  assignRealmRole,
+  deleteUser,
+  setUserEnabled,
+} from "@/lib/auth/keycloak-admin";
+import { requireApprover } from "@/lib/auth/session";
+import { findById, toWireRecord, update } from "@/lib/db/repository";
+import { signupsTable } from "@/lib/db/schema";
+
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const approver = requireApprover(req);
+  if (!approver) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+
+  const { action } = (await req.json()) as { action?: string };
+  if (action !== "approve" && action !== "reject") {
+    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  }
+
+  const { id } = await params;
+  const signup = await findById<SignupRecord>(signupsTable, id);
+  if (!signup) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  if (signup.status !== "pending") {
+    return NextResponse.json(
+      { error: `Already ${signup.status}` },
+      { status: 409 },
+    );
+  }
+
+  if (signup.keycloakUserId) {
+    if (action === "approve") {
+      await setUserEnabled(signup.keycloakUserId, true);
+      await assignRealmRole(
+        signup.keycloakUserId,
+        process.env.ADMIN_ROLE ?? "brockcsc-admin",
+      );
+    } else {
+      await deleteUser(signup.keycloakUserId);
+    }
+  }
+
+  const reviewed = await update<SignupRecord>(signupsTable, id, {
+    status: action === "approve" ? "approved" : "rejected",
+    reviewedBy: approver.email || approver.name,
+    reviewedAt: new Date().toISOString(),
+  });
+  if (!reviewed) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(toWireRecord(reviewed));
+};

--- a/app/api/signups/[id]/route.ts
+++ b/app/api/signups/[id]/route.ts
@@ -35,16 +35,20 @@ export const PATCH = async (
     );
   }
 
-  if (signup.keycloakUserId) {
-    if (action === "approve") {
-      await setUserEnabled(signup.keycloakUserId, true);
-      await assignRealmRole(
-        signup.keycloakUserId,
-        process.env.ADMIN_ROLE ?? "brockcsc-admin",
+  if (action === "approve") {
+    if (!signup.keycloakUserId) {
+      return NextResponse.json(
+        { error: "No Keycloak account is linked to this request." },
+        { status: 422 },
       );
-    } else {
-      await deleteUser(signup.keycloakUserId);
     }
+    await setUserEnabled(signup.keycloakUserId, true);
+    await assignRealmRole(
+      signup.keycloakUserId,
+      process.env.ADMIN_ROLE ?? "brockcsc-admin",
+    );
+  } else if (signup.keycloakUserId) {
+    await deleteUser(signup.keycloakUserId);
   }
 
   const reviewed = await update<SignupRecord>(signupsTable, id, {

--- a/app/api/signups/route.ts
+++ b/app/api/signups/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { SignupRecord } from "@/lib/api/types";
+import { requireApprover } from "@/lib/auth/session";
+import { findAll, toWireRecord } from "@/lib/db/repository";
+import { signupsTable } from "@/lib/db/schema";
+
+export const GET = async (req: NextRequest) => {
+  if (!requireApprover(req)) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+  const signups = await findAll<SignupRecord>(signupsTable);
+  return NextResponse.json(signups.map(toWireRecord));
+};

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -12,6 +12,15 @@ export {
   createEvent,
   editEvent,
   deleteEvent,
+  fetchSignups,
+  reviewSignup,
+  fetchInviteCode,
 } from "./records";
 export { fetchCurrentUser, login, logout } from "./auth";
-export type { EventRecord, ExecRecord, SessionUser, WithKey } from "./types";
+export type {
+  EventRecord,
+  ExecRecord,
+  SessionUser,
+  SignupRecord,
+  WithKey,
+} from "./types";

--- a/lib/api/records.ts
+++ b/lib/api/records.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "./client";
-import type { EventRecord, ExecRecord, WithKey } from "./types";
+import type { EventRecord, ExecRecord, SignupRecord, WithKey } from "./types";
 import { getEventStartTimestamp, getEventTiming } from "@/lib/events/schedule";
 
 export const fetchAllExecs = async (): Promise<WithKey<ExecRecord>[]> =>
@@ -95,3 +95,21 @@ export const createEvent = async (event: EventRecord): Promise<void> => {
 export const deleteEvent = async (eventId: string): Promise<void> => {
   await apiFetch(`/api/events/${eventId}`, { method: "DELETE" });
 };
+
+export const fetchSignups = async (): Promise<WithKey<SignupRecord>[]> =>
+  apiFetch<WithKey<SignupRecord>[]>("/api/signups");
+
+export const reviewSignup = async (
+  key: string,
+  action: "approve" | "reject",
+): Promise<void> => {
+  await apiFetch(`/api/signups/${key}`, {
+    method: "PATCH",
+    body: JSON.stringify({ action }),
+  });
+};
+
+export const fetchInviteCode = async (): Promise<{
+  code: string;
+  expiresInMs: number;
+}> => apiFetch("/api/invite-code");

--- a/lib/db/repository.ts
+++ b/lib/db/repository.ts
@@ -12,7 +12,7 @@ const toEntity = <T>(row: { id: string; data: unknown }): Entity<T> => ({
   ...(row.data as T),
 });
 
-const toWireRecord = <T>(entity: Entity<T>) => {
+export const toWireRecord = <T>(entity: Entity<T>) => {
   const { id, ...rest } = entity;
   return { $key: id, ...rest };
 };


### PR DESCRIPTION
- `/api/signups` GET (approver-gated) and PATCH approve/reject, which enables + roles or deletes the Keycloak account
- `/api/invite-code` GET (admin-gated) returning the current code and time until rotation
- New admin "Sign-up Requests" tab listing pending then processed requests, with a reject confirmation