### PR TITLE
Add public exec sign-up page and API

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { SignupRecord } from "@/lib/api/types";
+import { isValidInviteCode } from "@/lib/auth/invite-code";
+import {
+  createDisabledUser,
+  deleteUser,
+  findUserByUsername,
+  usernameFor,
+} from "@/lib/auth/keycloak-admin";
+import { create } from "@/lib/db/repository";
+import { signupsTable } from "@/lib/db/schema";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const badRequest = (error: string) =>
+  NextResponse.json({ error }, { status: 400 });
+
+export const POST = async (req: NextRequest) => {
+  const body = (await req.json()) as Record<string, string | undefined>;
+  const inviteCode = body.inviteCode?.trim() ?? "";
+  const firstName = body.firstName?.trim() ?? "";
+  const lastName = body.lastName?.trim() ?? "";
+  const email = body.email?.trim() ?? "";
+  const phone = body.phone?.trim() ?? "";
+  const password = body.password ?? "";
+
+  if (!isValidInviteCode(inviteCode)) {
+    return NextResponse.json(
+      { error: "That invite code is not valid." },
+      { status: 403 },
+    );
+  }
+  if (!firstName || !lastName) {
+    return badRequest("First and last name are required.");
+  }
+  if (!EMAIL_PATTERN.test(email)) {
+    return badRequest("Enter a valid email address.");
+  }
+  if (password.length < 8) {
+    return badRequest("Password must be at least 8 characters.");
+  }
+  if (password !== body.confirmPassword) {
+    return badRequest("Passwords do not match.");
+  }
+
+  const username = usernameFor(firstName, lastName);
+  if (await findUserByUsername(username)) {
+    return NextResponse.json(
+      { error: "That username is already taken." },
+      { status: 409 },
+    );
+  }
+
+  const keycloakUserId = await createDisabledUser({
+    username,
+    email,
+    firstName,
+    lastName,
+    password,
+    attributes: phone ? { phone: [phone] } : undefined,
+  });
+
+  try {
+    await create<SignupRecord>(signupsTable, {
+      firstName,
+      lastName,
+      username,
+      email,
+      phone: phone || undefined,
+      keycloakUserId,
+      status: "pending",
+      submittedAt: new Date().toISOString(),
+    });
+  } catch (err) {
+    // Don't orphan a Keycloak account we have no signup record for.
+    await deleteUser(keycloakUserId);
+    throw err;
+  }
+
+  return new NextResponse(null, { status: 201 });
+};

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { signup } from "@/lib/api";
+import { usernameFor } from "@/lib/auth/keycloak-admin";
+
+const Field = ({
+  id,
+  label,
+  optional,
+  ...props
+}: {
+  id: string;
+  label: string;
+  optional?: boolean;
+} & React.ComponentProps<"input">) => (
+  <div>
+    <label className="mb-1 block text-sm font-bold" htmlFor={id}>
+      {label}
+      {optional && (
+        <span className="font-normal text-muted-foreground"> (optional)</span>
+      )}
+    </label>
+    <input
+      id={id}
+      className="w-full rounded-[10px] border-2 border-black px-3 py-2"
+      {...props}
+    />
+  </div>
+);
+
+export default function SignupPage() {
+  const [form, setForm] = useState({
+    inviteCode: "",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    password: "",
+    confirmPassword: "",
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const set =
+    (key: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
+      setForm((prev) => ({ ...prev, [key]: e.target.value }));
+
+  const username = usernameFor(form.firstName, form.lastName);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (form.password !== form.confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await signup(form);
+      setSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[70vh] items-center justify-center px-4 py-10">
+      {submitted ? (
+        <div className="w-full max-w-md rounded-[20px] border-2 border-black bg-white p-8 text-center shadow-[6px_6px_0_0_#000]">
+          <h1 className="mb-2 text-2xl font-extrabold text-[#9A4440]">
+            Request submitted
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Your account <span className="font-bold">{username}</span> is
+            waiting for an admin to approve it. You can{" "}
+            <Link href="/admin" className="underline">
+              sign in
+            </Link>{" "}
+            once it is approved.
+          </p>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="w-full max-w-md rounded-[20px] border-2 border-black bg-white p-8 shadow-[6px_6px_0_0_#000]"
+        >
+          <h1 className="mb-1 text-center text-2xl font-extrabold text-[#9A4440]">
+            Request an exec account
+          </h1>
+          <p className="mb-6 text-center text-sm text-muted-foreground">
+            An admin approves your account before you can sign in.
+          </p>
+
+          <div className="flex flex-col gap-4">
+            <Field
+              id="inviteCode"
+              label="Invite code"
+              value={form.inviteCode}
+              onChange={set("inviteCode")}
+              autoFocus
+              required
+            />
+
+            <div className="grid grid-cols-2 gap-3">
+              <Field
+                id="firstName"
+                label="First name"
+                value={form.firstName}
+                onChange={set("firstName")}
+                required
+              />
+              <Field
+                id="lastName"
+                label="Last name"
+                value={form.lastName}
+                onChange={set("lastName")}
+                required
+              />
+            </div>
+
+            {username && (
+              <p className="text-sm text-muted-foreground">
+                Your username will be{" "}
+                <span className="font-bold text-[#9A4440]">{username}</span>
+              </p>
+            )}
+
+            <Field
+              id="email"
+              label="Email"
+              type="email"
+              value={form.email}
+              onChange={set("email")}
+              required
+            />
+            <Field
+              id="phone"
+              label="Phone"
+              type="tel"
+              optional
+              value={form.phone}
+              onChange={set("phone")}
+            />
+            <Field
+              id="password"
+              label="Password"
+              type="password"
+              value={form.password}
+              onChange={set("password")}
+              minLength={8}
+              required
+            />
+            <Field
+              id="confirmPassword"
+              label="Confirm password"
+              type="password"
+              value={form.confirmPassword}
+              onChange={set("confirmPassword")}
+              minLength={8}
+              required
+            />
+          </div>
+
+          {error && (
+            <p className="mt-4 text-sm font-semibold text-red-600">{error}</p>
+          )}
+
+          <Button type="submit" className="mt-6 w-full" disabled={submitting}>
+            {submitting ? "Submitting..." : "Request account"}
+          </Button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { signup } from "@/lib/api";
-import { usernameFor } from "@/lib/auth/keycloak-admin";
+import { usernameFor } from "@/lib/auth/username";
 
 const Field = ({
   id,

--- a/app/team/pageClient.tsx
+++ b/app/team/pageClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
 import {
@@ -172,6 +173,18 @@ export default function TeamPageClient() {
           </div>
         )}
       </section>
+
+      <p className="px-4 text-[0.85rem] text-muted-foreground">
+        Are you an exec?{" "}
+        <Link href="/signup" className="underline">
+          Request an account
+        </Link>{" "}
+        or{" "}
+        <Link href="/admin" className="underline">
+          sign in
+        </Link>
+        .
+      </p>
     </main>
   );
 }

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { apiFetch, ApiError } from "./client";
-import type { SessionUser } from "./types";
+import type { SessionUser, SignupInput } from "./types";
 
 export const fetchCurrentUser = async (): Promise<SessionUser | null> => {
   try {
@@ -23,4 +23,17 @@ export const login = async (
 
 export const logout = async (): Promise<void> => {
   await apiFetch("/api/auth/logout", { method: "POST" });
+};
+
+/** Not apiFetch: the sign-up form shows the server's rejection reason. */
+export const signup = async (input: SignupInput): Promise<void> => {
+  const res = await fetch("/api/signup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? "Could not submit your request right now.");
+  }
 };

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -13,5 +13,11 @@ export {
   editEvent,
   deleteEvent,
 } from "./records";
-export { fetchCurrentUser, login, logout } from "./auth";
-export type { EventRecord, ExecRecord, SessionUser, WithKey } from "./types";
+export { fetchCurrentUser, login, logout, signup } from "./auth";
+export type {
+  EventRecord,
+  ExecRecord,
+  SessionUser,
+  SignupInput,
+  WithKey,
+} from "./types";

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -28,6 +28,16 @@ export type ExecRecord = {
   };
 };
 
+export type SignupInput = {
+  inviteCode: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  password: string;
+  confirmPassword: string;
+};
+
 export type SignupStatus = "pending" | "approved" | "rejected";
 
 export type SignupRecord = {

--- a/lib/auth/keycloak-admin.ts
+++ b/lib/auth/keycloak-admin.ts
@@ -153,6 +153,4 @@ export const assignRealmRole = async (userId: string, roleName: string) => {
   }
 };
 
-/** firstname + lastname, lowercased, non-alphanumerics stripped. */
-export const usernameFor = (firstName: string, lastName: string): string =>
-  `${firstName}${lastName}`.toLowerCase().replace(/[^a-z0-9]/g, "");
+export { usernameFor } from "./username";

--- a/lib/auth/username.ts
+++ b/lib/auth/username.ts
@@ -1,0 +1,4 @@
+/** firstname + lastname, lowercased, non-alphanumerics stripped. Shared by the
+ * sign-up form and the server, so the preview can't drift from what's created. */
+export const usernameFor = (firstName: string, lastName: string): string =>
+  `${firstName}${lastName}`.toLowerCase().replace(/[^a-z0-9]/g, "");

--- a/lib/db/repository.ts
+++ b/lib/db/repository.ts
@@ -2,9 +2,9 @@ import { eq, sql } from "drizzle-orm";
 import { NextResponse, type NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/auth/session";
 import { db } from "./index";
-import type { eventsTable, execsTable } from "./schema";
+import type { eventsTable, execsTable, signupsTable } from "./schema";
 
-type JsonbTable = typeof eventsTable | typeof execsTable;
+type JsonbTable = typeof eventsTable | typeof execsTable | typeof signupsTable;
 type Entity<T> = T & { id: string };
 
 const toEntity = <T>(row: { id: string; data: unknown }): Entity<T> => ({


### PR DESCRIPTION
- `/signup` page: invite code, name, email, optional phone, password, with the derived username shown live.
- `POST /api/signup` validates the invite code, creates a disabled Keycloak user, and records a pending signup (Keycloak user is deleted if the DB insert fails).
- Team page links execs to `/signup` and `/admin`.