### PR TITLE
Add local development setup

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,15 @@
+# Copy to .env.local (gitignored) for local development.
+
+# Matches deploy/docker-compose.dev.yml (npm run db:up).
+DATABASE_URL=postgresql://brockcsc:brockcsc@localhost:5432/brockcsc
+DB_SCHEMA=local
+
+KEYCLOAK_ISSUER=https://auth.wayfarerbx.com/realms/brockcsc
+KEYCLOAK_CLIENT_ID=brockcsc-web
+# >>> The only value you must obtain out-of-band: ask a club admin or read it
+# >>> from the Komodo stack config. Never commit it.
+KEYCLOAK_CLIENT_SECRET=
+ADMIN_ROLE=brockcsc-admin
+
+# Any random string is fine locally.
+SESSION_JWT_SECRET=local-dev-session-secret

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files
 .env
+.env.local
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ The whole site leans neubrutalist: flat colours, thick black outlines, and hard 
 
 <br />
 
+## Local development
+
+You need Node 22+, Docker (for the local Postgres), and the Keycloak client secret.
+
+Production Postgres lives on the VPS and isn't reachable from your machine, so local dev runs its own throwaway Postgres in Docker. Keycloak is public, so you log in against the real thing.
+
+```bash
+git clone git@github.com:BrockCSC/website.git && cd website
+npm ci
+npm run db:up                       # local Postgres 16 on :5432
+cp .env.local.example .env.local    # then fill in KEYCLOAK_CLIENT_SECRET
+npm run dev                         # migrations run first, then http://localhost:3000
+```
+
+Open `http://localhost:3000/admin` and the login form appears. Sign in with your real Keycloak username and password.
+
+**The client secret.** `KEYCLOAK_CLIENT_SECRET` is the one value you can't make up. Ask a club admin for it, or copy it out of the Komodo stack config. It never goes in a committed file — `.env.local` is gitignored, keep it that way.
+
+**You also need the admin role.** A correct password isn't enough. Your Keycloak account needs the `brockcsc-admin` realm role, or login fails with a 403 "Not authorized". If that happens, ask an admin to grant you the role in the `brockcsc` realm.
+
+The session cookie is `Secure`, which Chrome and Firefox happily set on `http://localhost`. Safari doesn't, so use Chrome or Firefox locally.
+
+`npm run db:down` stops the database. Data lives in a named Docker volume, so it survives restarts. Local dev writes to the `local` schema, entirely separate from `prod` and `uat`.
+
+<br />
+
 <div align="center">
 
 ## Come say hi

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+# Local dev Postgres only - production Postgres lives on the VPS.
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: brockcsc-dev-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: brockcsc
+      POSTGRES_USER: brockcsc
+      POSTGRES_PASSWORD: brockcsc
+    ports:
+      - "5432:5432"
+    volumes:
+      - brockcsc-dev-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U brockcsc -d brockcsc"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  brockcsc-dev-postgres:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "node scripts/migrate.mjs",
+    "predev": "node --env-file-if-exists=.env.local scripts/migrate.mjs",
     "dev": "next dev --webpack",
     "build": "next build",
     "start": "next start",
@@ -12,7 +12,9 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "node scripts/migrate.mjs"
+    "db:migrate": "node --env-file-if-exists=.env.local scripts/migrate.mjs",
+    "db:up": "docker compose -f deploy/docker-compose.dev.yml up -d",
+    "db:down": "docker compose -f deploy/docker-compose.dev.yml down"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -4,7 +4,11 @@ import { Pool } from "pg";
 
 const connectionString = process.env.DATABASE_URL;
 if (!connectionString) {
-  throw new Error("DATABASE_URL env var is not set.");
+  console.error(
+    "DATABASE_URL env var is not set.\n" +
+      "For local dev: run `npm run db:up`, then `cp .env.local.example .env.local`.",
+  );
+  process.exit(1);
 }
 
 const schema = process.env.DB_SCHEMA ?? "public";


### PR DESCRIPTION
- Local Postgres 16 via `deploy/docker-compose.dev.yml`, started with `npm run db:up` / stopped with `npm run db:down`
- `.env.local.example` with working local defaults; only `KEYCLOAK_CLIENT_SECRET` must be obtained out-of-band (`.env.local` now gitignored)
- README "Local development" section, and `predev` now prints an actionable message instead of a stack trace when `DATABASE_URL` is unset