### PR TITLE
Upload images, restrict executive management, redesign profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 RUN addgroup --system --gid 1001 nodejs && adduser --system --uid 1001 nextjs
 
+# Owned up front so a fresh uploads volume inherits nextjs, not root.
+RUN mkdir -p /data/uploads && chown -R nextjs:nodejs /data
+
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static

--- a/app/admin/events/event-modal.tsx
+++ b/app/admin/events/event-modal.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { ImageUpload } from "@/components/ui/image-upload";
 import Modal from "@/components/ui/modal";
 import { useState } from "react";
 import { EventRecord, WithKey, createEvent, editEvent } from "@/lib/api";
@@ -168,15 +169,10 @@ export default function EventModal({
           />
         </div>
         <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">
-            Poster Photo URL
-          </label>
-          <input
-            type="url"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://example.com/poster.png"
+          <ImageUpload
+            label="Poster image"
+            onChange={setPosterUrl}
             value={posterUrl}
-            onChange={(e) => setPosterUrl(e.target.value)}
           />
         </div>
         <div className="flex gap-4 mb-4">

--- a/app/admin/execs/exec-modal.tsx
+++ b/app/admin/execs/exec-modal.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { ImageUpload } from "@/components/ui/image-upload";
 import Modal from "@/components/ui/modal";
 import { ExecRecord, WithKey, createExec, updateExec } from "@/lib/api";
 import { useState } from "react";
@@ -184,15 +185,10 @@ export default function ExecModal({
           />
         </div>
         <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">
-            Profile Photo URL
-          </label>
-          <input
-            type="url"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://example.com/photo.png"
+          <ImageUpload
+            label="Profile photo"
+            onChange={setPhotoUrl}
             value={photoUrl}
-            onChange={(e) => setPhotoUrl(e.target.value)}
           />
         </div>
         {saveError && (

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -9,7 +9,7 @@ import { LoginForm } from "@/components/admin/login-form";
 const adminTabs = [
   { name: "Dashboard", href: "/admin" },
   { name: "Events Management", href: "/admin/events" },
-  { name: "Executives Management", href: "/admin/execs" },
+  { name: "Executives Management", href: "/admin/execs", approverOnly: true },
   { name: "My Profile", href: "/admin/profile" },
 ];
 
@@ -22,6 +22,7 @@ export default function AdminLayout({
   const pathname = usePathname();
   const [loading, setLoading] = useState(true);
   const [authenticated, setAuthenticated] = useState(false);
+  const [isApprover, setIsApprover] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -29,6 +30,7 @@ export default function AdminLayout({
     fetchCurrentUser().then((user) => {
       if (cancelled) return;
       setAuthenticated(!!user);
+      setIsApprover(!!user?.isApprover);
       setLoading(false);
     });
 
@@ -64,25 +66,27 @@ export default function AdminLayout({
       <div className="mx-auto w-full max-w-[1060px] px-5">
         <div className="flex items-center justify-between mb-8">
           <nav className="flex gap-2">
-            {adminTabs.map((tab) => {
-              const isActive =
-                tab.href === "/admin"
-                  ? pathname === "/admin"
-                  : pathname.startsWith(tab.href);
-              return (
-                <Link
-                  key={tab.name}
-                  href={tab.href}
-                  className={`px-4 py-2 rounded-[12px] font-semibold border-2 border-transparent transition-colors ${
-                    isActive
-                      ? "border-[#9A4440] text-[#9A4440] bg-[#fff1f0]"
-                      : "text-black hover:bg-neutral-100"
-                  }`}
-                >
-                  {tab.name}
-                </Link>
-              );
-            })}
+            {adminTabs
+              .filter((tab) => !tab.approverOnly || isApprover)
+              .map((tab) => {
+                const isActive =
+                  tab.href === "/admin"
+                    ? pathname === "/admin"
+                    : pathname.startsWith(tab.href);
+                return (
+                  <Link
+                    key={tab.name}
+                    href={tab.href}
+                    className={`px-4 py-2 rounded-[12px] font-semibold border-2 border-transparent transition-colors ${
+                      isActive
+                        ? "border-[#9A4440] text-[#9A4440] bg-[#fff1f0]"
+                        : "text-black hover:bg-neutral-100"
+                    }`}
+                  >
+                    {tab.name}
+                  </Link>
+                );
+              })}
           </nav>
           <div className="flex items-center gap-3">
             <button

--- a/app/admin/profile/page.tsx
+++ b/app/admin/profile/page.tsx
@@ -3,23 +3,53 @@
 import { Button } from "@/components/ui/button";
 import { ImageUpload } from "@/components/ui/image-upload";
 import { ExecRecord, WithKey, fetchProfile, updateProfile } from "@/lib/api";
+import { TeamMemberCard } from "@/app/team/components/team-member-card";
 import { useEffect, useState } from "react";
 
 type TeamMember = WithKey<ExecRecord>;
 
+const SOCIALS = [
+  { key: "github", label: "GitHub", hint: "github.com/username" },
+  { key: "linkedin", label: "LinkedIn", hint: "linkedin.com/in/username" },
+  { key: "instagram", label: "Instagram", hint: "instagram.com/username" },
+  { key: "x", label: "X", hint: "x.com/username" },
+] as const;
+
+type SocialKey = (typeof SOCIALS)[number]["key"];
+
+const field = "w-full rounded-[10px] border-2 border-black px-3 py-2 text-sm";
+
+const Section = ({
+  title,
+  note,
+  children,
+}: {
+  title: string;
+  note?: string;
+  children: React.ReactNode;
+}) => (
+  <section className="rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_#9A4440]">
+    <h2 className="text-sm font-bold uppercase tracking-wide">{title}</h2>
+    {note && <p className="mt-1 text-sm text-neutral-500">{note}</p>}
+    <div className="mt-4">{children}</div>
+  </section>
+);
+
 export default function ProfilePage() {
   const [profile, setProfile] = useState<TeamMember | null>(null);
   const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
   const [description, setDescription] = useState("");
   const [term, setTerm] = useState("");
   const [hidden, setHidden] = useState(false);
-  const [github, setGithub] = useState("");
-  const [linkedin, setLinkedin] = useState("");
-  const [instagram, setInstagram] = useState("");
-  const [twitter, setTwitter] = useState("");
   const [photoUrl, setPhotoUrl] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
-  const [status, setStatus] = useState<string | null>(null);
+  const [socials, setSocials] = useState<Record<SocialKey, string>>({
+    github: "",
+    linkedin: "",
+    instagram: "",
+    x: "",
+  });
 
   useEffect(() => {
     void (async () => {
@@ -29,22 +59,24 @@ export default function ProfilePage() {
         setDescription(exec?.description ?? "");
         setTerm(exec?.term ?? "");
         setHidden(exec?.hidden ?? false);
-        setGithub(exec?.socials?.github ?? "");
-        setLinkedin(exec?.socials?.linkedin ?? "");
-        setInstagram(exec?.socials?.instagram ?? "");
-        setTwitter(exec?.socials?.x ?? "");
         setPhotoUrl(exec?.image?.url ?? "");
+        setSocials({
+          github: exec?.socials?.github ?? "",
+          linkedin: exec?.socials?.linkedin ?? "",
+          instagram: exec?.socials?.instagram ?? "",
+          x: exec?.socials?.x ?? "",
+        });
       } catch {
-        setStatus("Couldn't load your profile. Please try again in a moment.");
+        setStatus("Couldn't load your profile. Refresh to try again.");
       } finally {
         setLoading(false);
       }
     })();
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const save = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsSaving(true);
+    setSaving(true);
     setStatus(null);
     try {
       await updateProfile({
@@ -52,13 +84,13 @@ export default function ProfilePage() {
         term,
         hidden,
         image: { url: photoUrl },
-        socials: { github, linkedin, instagram, x: twitter },
+        socials,
       });
-      setStatus("Profile saved.");
+      setStatus("Saved.");
     } catch {
-      setStatus("Couldn't save your profile. Please try again in a moment.");
+      setStatus("Couldn't save. Try again in a moment.");
     } finally {
-      setIsSaving(false);
+      setSaving(false);
     }
   };
 
@@ -69,123 +101,167 @@ export default function ProfilePage() {
   if (!profile) {
     return (
       <div>
-        <h1 className="text-2xl font-bold mb-2">My Profile</h1>
+        <h1 className="mb-2 text-2xl font-bold">My Profile</h1>
         <p className="text-neutral-500">
           Your account isn&apos;t linked to a team page tile. Ask a co-president
-          to sort it out — tiles are linked when an account is approved.
+          to link it — that happens when an account is approved.
         </p>
       </div>
     );
   }
 
+  const preview: TeamMember = {
+    ...profile,
+    description,
+    term,
+    socials,
+    image: { url: photoUrl },
+  };
+
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-2">My Profile</h1>
-      <p className="text-neutral-500 mb-6">
-        Update how you appear on the team page.
+      <h1 className="mb-1 text-2xl font-bold">My Profile</h1>
+      <p className="mb-8 text-neutral-500">
+        Everything here is public. The card on the left is exactly what visitors
+        see.
       </p>
-      <form onSubmit={handleSubmit} className="max-w-md">
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">Full Name</label>
-          <p className="font-semibold">{profile.name}</p>
-        </div>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">Role</label>
-          <p className="font-semibold">{profile.title}</p>
-          <p className="text-xs text-neutral-500 mt-1">
-            Your name and role can only be changed by a co-president.
-          </p>
-        </div>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">
-            Description
-          </label>
-          <textarea
-            className="w-full rounded border px-3 py-2"
-            placeholder="A short bio..."
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">
-            Term (e.g. 2016-2017)
-          </label>
-          <input
-            type="text"
-            className="w-full rounded border px-3 py-2"
-            placeholder="2016-2017"
-            value={term}
-            onChange={(e) => setTerm(e.target.value)}
-          />
+
+      <form
+        className="grid gap-8 lg:grid-cols-[320px_1fr] lg:items-start"
+        onSubmit={save}
+      >
+        <div className="lg:sticky lg:top-6">
+          <div className="mb-3 flex items-center gap-2">
+            <span className="text-xs font-bold uppercase tracking-wide">
+              Live preview
+            </span>
+            {hidden && (
+              <span className="rounded-full border-2 border-black bg-neutral-200 px-2 py-0.5 text-[10px] font-bold uppercase">
+                Hidden
+              </span>
+            )}
+          </div>
+          <div className={hidden ? "opacity-40 grayscale" : undefined}>
+            <TeamMemberCard member={preview} />
+          </div>
+          {hidden && (
+            <p className="mt-3 text-xs text-neutral-500">
+              You&apos;re hidden, so this card isn&apos;t on the team page right
+              now.
+            </p>
+          )}
         </div>
 
-        <label className="my-6 flex items-start gap-2 text-sm">
-          <input
-            checked={hidden}
-            className="mt-1"
-            onChange={(e) => setHidden(e.target.checked)}
-            type="checkbox"
-          />
-          <span>
-            Hide me from the public team page
-            <span className="block text-neutral-500">
-              Your tile stays in the admin panel and your login keeps working —
-              it just isn&apos;t shown on the website.
-            </span>
-          </span>
-        </label>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">Github URL</label>
-          <input
-            type="text"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://github.com/username"
-            value={github}
-            onChange={(e) => setGithub(e.target.value)}
-          />
+        <div className="flex flex-col gap-6">
+          <Section
+            note="Only a co-president can change these."
+            title="Identity"
+          >
+            <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-sm">
+              <dt className="font-semibold text-neutral-500">Name</dt>
+              <dd className="font-bold">{profile.name}</dd>
+              <dt className="font-semibold text-neutral-500">Role</dt>
+              <dd className="font-bold">{profile.title ?? "—"}</dd>
+            </dl>
+          </Section>
+
+          <Section title="Photo">
+            <ImageUpload label="" onChange={setPhotoUrl} value={photoUrl} />
+          </Section>
+
+          <Section title="About you">
+            <label className="mb-1 block text-sm font-semibold" htmlFor="about">
+              Short bio
+            </label>
+            <textarea
+              className={`${field} min-h-[110px]`}
+              id="about"
+              maxLength={400}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What you work on, what you're into, what you'd help someone with."
+              value={description}
+            />
+            <div className="mt-1 text-right text-xs text-neutral-400">
+              {description.length}/400
+            </div>
+
+            <label
+              className="mb-1 mt-3 block text-sm font-semibold"
+              htmlFor="term"
+            >
+              Term
+            </label>
+            <input
+              className={field}
+              id="term"
+              onChange={(e) => setTerm(e.target.value)}
+              placeholder="2025-2026"
+              value={term}
+            />
+          </Section>
+
+          <Section
+            note="Leave blank to hide an icon on your card."
+            title="Links"
+          >
+            <div className="grid gap-3 sm:grid-cols-2">
+              {SOCIALS.map(({ key, label, hint }) => (
+                <div key={key}>
+                  <label
+                    className="mb-1 block text-sm font-semibold"
+                    htmlFor={key}
+                  >
+                    {label}
+                  </label>
+                  <input
+                    className={field}
+                    id={key}
+                    onChange={(e) =>
+                      setSocials((s) => ({ ...s, [key]: e.target.value }))
+                    }
+                    placeholder={hint}
+                    value={socials[key]}
+                  />
+                </div>
+              ))}
+            </div>
+          </Section>
+
+          <Section title="Visibility">
+            <label className="flex items-start gap-3 text-sm">
+              <input
+                checked={hidden}
+                className="mt-1 size-4"
+                onChange={(e) => setHidden(e.target.checked)}
+                type="checkbox"
+              />
+              <span>
+                <span className="font-semibold">
+                  Hide me from the team page
+                </span>
+                <span className="block text-neutral-500">
+                  Your tile and login stay exactly as they are — the website
+                  just doesn&apos;t show you.
+                </span>
+              </span>
+            </label>
+          </Section>
+
+          <div className="flex items-center gap-4">
+            <Button disabled={saving} type="submit" variant="primary">
+              {saving ? "Saving..." : "Save changes"}
+            </Button>
+            {status && (
+              <span
+                className={`text-sm font-semibold ${
+                  status === "Saved." ? "text-neutral-600" : "text-[#d44b4b]"
+                }`}
+              >
+                {status}
+              </span>
+            )}
+          </div>
         </div>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">LinkedIn</label>
-          <input
-            type="url"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://www.linkedin.com/in/username"
-            value={linkedin}
-            onChange={(e) => setLinkedin(e.target.value)}
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">Instagram</label>
-          <input
-            type="url"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://www.instagram.com/username"
-            value={instagram}
-            onChange={(e) => setInstagram(e.target.value)}
-          />
-        </div>
-        <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">X URL</label>
-          <input
-            type="url"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://twitter.com/username"
-            value={twitter}
-            onChange={(e) => setTwitter(e.target.value)}
-          />
-        </div>
-        <div className="mb-4">
-          <ImageUpload
-            label="Profile photo"
-            onChange={setPhotoUrl}
-            value={photoUrl}
-          />
-        </div>
-        {status && <p className="mb-4 text-sm font-semibold">{status}</p>}
-        <Button variant="primary" type="submit" disabled={isSaving}>
-          {isSaving ? "Saving..." : "Save Profile"}
-        </Button>
       </form>
     </div>
   );

--- a/app/admin/profile/page.tsx
+++ b/app/admin/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { ImageUpload } from "@/components/ui/image-upload";
 import { ExecRecord, WithKey, fetchProfile, updateProfile } from "@/lib/api";
 import { useEffect, useState } from "react";
 
@@ -175,15 +176,10 @@ export default function ProfilePage() {
           />
         </div>
         <div className="mb-4">
-          <label className="block text-sm font-semibold mb-1">
-            Profile Photo URL
-          </label>
-          <input
-            type="url"
-            className="w-full rounded border px-3 py-2"
-            placeholder="https://example.com/photo.png"
+          <ImageUpload
+            label="Profile photo"
+            onChange={setPhotoUrl}
             value={photoUrl}
-            onChange={(e) => setPhotoUrl(e.target.value)}
           />
         </div>
         {status && <p className="mb-4 text-sm font-semibold">{status}</p>}

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { getSessionUser } from "@/lib/auth/session";
+import { getSessionUser, requireApprover } from "@/lib/auth/session";
 
 export const GET = (req: NextRequest) => {
   const user = getSessionUser(req);
   if (!user) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
-  return NextResponse.json(user);
+  return NextResponse.json({ ...user, isApprover: !!requireApprover(req) });
 };

--- a/app/api/execs/[id]/route.ts
+++ b/app/api/execs/[id]/route.ts
@@ -1,22 +1,39 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { requireAdmin } from "@/lib/auth/session";
+import { requireApprover } from "@/lib/auth/session";
 import {
   createItemHandlers,
   findAll,
   remove,
+  toWireRecord,
   update,
 } from "@/lib/db/repository";
 import { execsTable, signupsTable } from "@/lib/db/schema";
 import type { ExecRecord, SignupRecord } from "@/lib/api/types";
 
-export const { GET, PATCH } = createItemHandlers<ExecRecord>(execsTable);
+export const { GET } = createItemHandlers<ExecRecord>(execsTable);
+
+export const PATCH = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  if (!requireApprover(req)) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+  const { id } = await params;
+  const patch = (await req.json()) as Partial<ExecRecord>;
+  const entity = await update<ExecRecord>(execsTable, id, patch);
+  if (!entity) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(toWireRecord(entity));
+};
 
 /** Also unlinks any account pointing at this tile, so nothing dangles. */
 export const DELETE = async (
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) => {
-  if (!requireAdmin(req)) {
+  if (!requireApprover(req)) {
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
 

--- a/app/api/execs/route.ts
+++ b/app/api/execs/route.ts
@@ -1,5 +1,24 @@
-import { createCollectionHandlers } from "@/lib/db/repository";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireApprover } from "@/lib/auth/session";
+import {
+  create,
+  createCollectionHandlers,
+  toWireRecord,
+} from "@/lib/db/repository";
 import { execsTable } from "@/lib/db/schema";
 import type { ExecRecord } from "@/lib/api/types";
 
-export const { GET, POST } = createCollectionHandlers<ExecRecord>(execsTable);
+export const { GET } = createCollectionHandlers<ExecRecord>(execsTable);
+
+export const POST = async (req: NextRequest) => {
+  if (!requireApprover(req)) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+  const input = (await req.json()) as ExecRecord;
+  return NextResponse.json(
+    toWireRecord(await create<ExecRecord>(execsTable, input)),
+    {
+      status: 201,
+    },
+  );
+};

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -1,0 +1,41 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { NextResponse, type NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/auth/session";
+import {
+  isAllowedImageType,
+  MAX_UPLOAD_BYTES,
+  UPLOAD_ROOT,
+  uploadNameFor,
+} from "@/lib/uploads";
+
+export const POST = async (req: NextRequest) => {
+  if (!requireAdmin(req)) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+
+  const form = await req.formData();
+  const file = form.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided." }, { status: 400 });
+  }
+  if (!isAllowedImageType(file.type)) {
+    return NextResponse.json(
+      { error: "Only JPEG, PNG, WebP, GIF or AVIF images are allowed." },
+      { status: 415 },
+    );
+  }
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "That image is larger than 5MB." },
+      { status: 413 },
+    );
+  }
+
+  const name = uploadNameFor(file.type);
+  const target = join(UPLOAD_ROOT, name);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, Buffer.from(await file.arrayBuffer()));
+
+  return NextResponse.json({ url: `/uploads/${name}` }, { status: 201 });
+};

--- a/app/uploads/[...path]/route.ts
+++ b/app/uploads/[...path]/route.ts
@@ -1,0 +1,36 @@
+import { stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { Readable } from "node:stream";
+import { NextResponse } from "next/server";
+import { contentTypeForPath, resolveUploadPath } from "@/lib/uploads";
+
+export const GET = async (
+  _req: Request,
+  { params }: { params: Promise<{ path: string[] }> },
+) => {
+  const { path } = await params;
+  const resolved = resolveUploadPath(path);
+  if (!resolved) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  try {
+    const info = await stat(resolved);
+    if (!info.isFile()) return new NextResponse(null, { status: 404 });
+
+    const stream = Readable.toWeb(
+      createReadStream(resolved),
+    ) as ReadableStream<Uint8Array>;
+
+    return new NextResponse(stream, {
+      headers: {
+        "content-type": contentTypeForPath(resolved),
+        "content-length": String(info.size),
+        // Names are random, so a file never changes under the same URL.
+        "cache-control": "public, max-age=31536000, immutable",
+      },
+    });
+  } catch {
+    return new NextResponse(null, { status: 404 });
+  }
+};

--- a/components/ui/image-upload.tsx
+++ b/components/ui/image-upload.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Image from "next/image";
+import { useRef, useState } from "react";
+import { Button } from "./button";
+
+export function ImageUpload({
+  value,
+  onChange,
+  label = "Photo",
+}: {
+  value?: string;
+  onChange: (url: string) => void;
+  label?: string;
+}) {
+  const input = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const upload = async (file: File) => {
+    setUploading(true);
+    setError(null);
+    try {
+      const body = new FormData();
+      body.append("file", file);
+      const res = await fetch("/api/uploads", { method: "POST", body });
+      const data = (await res.json().catch(() => ({}))) as {
+        url?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.url) {
+        throw new Error(data.error ?? "Upload failed.");
+      }
+      onChange(data.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed.");
+    } finally {
+      setUploading(false);
+      if (input.current) input.current.value = "";
+    }
+  };
+
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-bold">{label}</label>
+      <div className="flex items-center gap-4">
+        <div className="relative size-20 shrink-0 overflow-hidden rounded-[12px] border-2 border-black bg-neutral-100">
+          {value ? (
+            <Image
+              alt=""
+              className="object-cover"
+              fill
+              src={value}
+              unoptimized
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-neutral-400">
+              None
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <input
+            accept="image/jpeg,image/png,image/webp,image/gif,image/avif"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) void upload(file);
+            }}
+            ref={input}
+            type="file"
+          />
+          <div className="flex gap-2">
+            <Button
+              disabled={uploading}
+              onClick={() => input.current?.click()}
+              size="xs"
+              type="button"
+              variant="secondary"
+            >
+              {uploading ? "Uploading..." : value ? "Replace" : "Upload"}
+            </Button>
+            {value && (
+              <Button
+                disabled={uploading}
+                onClick={() => onChange("")}
+                size="xs"
+                type="button"
+                variant="destructive"
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+          <span className="text-xs text-neutral-500">
+            JPEG, PNG, WebP, GIF or AVIF. Max 5MB.
+          </span>
+        </div>
+      </div>
+      {error && (
+        <p className="mt-2 text-sm font-semibold text-[#d44b4b]">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     container_name: ${PROJECT_NAME}-app
     restart: unless-stopped
     networks: [wayfarer-net]
+    volumes:
+      - uploads:/data/uploads
     environment:
       - DATABASE_URL=${DATABASE_URL}
       - DB_SCHEMA=${DB_SCHEMA}
@@ -24,6 +26,7 @@ services:
       - SESSION_JWT_SECRET=${SESSION_JWT_SECRET}
       - INVITE_CODE_SECRET=${INVITE_CODE_SECRET}
       - PORT=3000
+      - UPLOAD_DIR=/data/uploads
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health"]
       interval: 30s
@@ -36,3 +39,8 @@ services:
       - "traefik.http.routers.${PROJECT_NAME}-app.entrypoints=websecure"
       - "traefik.http.routers.${PROJECT_NAME}-app.tls.certresolver=letsencrypt"
       - "traefik.http.services.${PROJECT_NAME}-app.loadbalancer.server.port=3000"
+
+volumes:
+  uploads:
+    name: brockcsc-uploads
+    external: true

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -5,6 +5,8 @@ export type SessionUser = {
   email: string;
   name: string;
   roles: string[];
+  /** Holds the approver role, so may manage executives. */
+  isApprover?: boolean;
 };
 
 export type ExecSocialLinks = {

--- a/lib/uploads.ts
+++ b/lib/uploads.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto";
+import { extname, join, normalize, sep } from "node:path";
+
+/** Shared across every environment on the host, so preview envs see prod's images. */
+export const UPLOAD_ROOT = process.env.UPLOAD_DIR ?? "/data/uploads";
+
+export const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+const EXTENSION_BY_TYPE: Record<string, string> = {
+  "image/jpeg": ".jpg",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/avif": ".avif",
+};
+
+export const isAllowedImageType = (type: string) => type in EXTENSION_BY_TYPE;
+
+export const extensionForType = (type: string) => EXTENSION_BY_TYPE[type] ?? "";
+
+/** Random name keyed by date; the original filename is never trusted. */
+export const uploadNameFor = (contentType: string, now = new Date()) => {
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${yyyy}/${mm}/${randomUUID()}${extensionForType(contentType)}`;
+};
+
+/**
+ * Resolves a request path inside UPLOAD_ROOT, or null if it escapes.
+ * Without this, `..%2f..%2fetc/passwd` would be readable.
+ */
+export const resolveUploadPath = (segments: string[]): string | null => {
+  if (segments.some((s) => !s || s === "." || s === "..")) return null;
+  const relative = normalize(segments.join("/"));
+  if (relative.startsWith("..") || relative.startsWith(sep)) return null;
+  const resolved = join(UPLOAD_ROOT, relative);
+  return resolved.startsWith(UPLOAD_ROOT + sep) ? resolved : null;
+};
+
+export const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".gif": "image/gif",
+  ".avif": "image/avif",
+};
+
+export const contentTypeForPath = (path: string) =>
+  CONTENT_TYPE_BY_EXTENSION[extname(path).toLowerCase()] ??
+  "application/octet-stream";

--- a/scripts/migrate-images.mjs
+++ b/scripts/migrate-images.mjs
@@ -1,0 +1,103 @@
+/**
+ * Copies every remote image into the uploads volume and rewrites the record
+ * to a local /uploads/... path. Runs inside the app container.
+ *
+ *   DRY=1 node migrate-images.mjs     report only
+ *         node migrate-images.mjs     apply
+ *
+ * Idempotent: records already pointing at /uploads are skipped.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import pg from "pg";
+
+const DRY = process.env.DRY === "1";
+const SCHEMA = process.env.DB_SCHEMA ?? "prod";
+const ROOT = process.env.UPLOAD_DIR ?? "/data/uploads";
+
+const EXT = {
+  "image/jpeg": ".jpg",
+  // Legacy type IIS/older tooling used for .jfif; it is a normal JPEG.
+  "image/pjpeg": ".jpg",
+  // One event poster is genuinely a PDF. Preserve it rather than orphan it;
+  // the upload endpoint still refuses PDFs for anything new.
+  "application/pdf": ".pdf",
+  "image/png": ".png",
+  "image/webp": ".webp",
+  "image/gif": ".gif",
+  "image/avif": ".avif",
+};
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+
+const rows = [];
+for (const table of ["execs", "events"]) {
+  const res = await pool.query(
+    `SELECT id, data->>'name' AS name, data->>'title' AS title, data#>>'{image,url}' AS url
+     FROM "${SCHEMA}"."${table}" WHERE data#>>'{image,url}' IS NOT NULL`,
+  );
+  res.rows.forEach((r) => rows.push({ ...r, table }));
+}
+
+const remote = rows.filter((r) => /^https?:\/\//.test(r.url));
+const local = rows.length - remote.length;
+console.log(
+  `${rows.length} records with an image | ${remote.length} remote | ${local} already local`,
+);
+if (DRY) {
+  const hosts = {};
+  remote.forEach((r) => {
+    const h = new URL(r.url).host;
+    hosts[h] = (hosts[h] ?? 0) + 1;
+  });
+  console.log("hosts:", JSON.stringify(hosts));
+  await pool.end();
+  process.exit(0);
+}
+
+const mapping = [];
+let ok = 0;
+let failed = 0;
+
+for (const row of remote) {
+  try {
+    const res = await fetch(row.url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const type = (res.headers.get("content-type") ?? "").split(";")[0].trim();
+    const ext = EXT[type];
+    if (!ext) throw new Error(`unsupported content-type ${type || "(none)"}`);
+
+    const bytes = Buffer.from(await res.arrayBuffer());
+    if (!bytes.length) throw new Error("empty body");
+
+    const name = `migrated/${randomUUID()}${ext}`;
+    const target = join(ROOT, name);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, bytes);
+
+    const newUrl = `/uploads/${name}`;
+    await pool.query(
+      `UPDATE "${SCHEMA}"."${row.table}"
+       SET data = jsonb_set(data, '{image,url}', to_jsonb($1::text))
+       WHERE id = $2`,
+      [newUrl, row.id],
+    );
+
+    mapping.push({ table: row.table, id: row.id, from: row.url, to: newUrl });
+    ok++;
+  } catch (err) {
+    failed++;
+    console.log(`FAILED ${row.table} ${row.name ?? row.id}: ${err.message}`);
+    console.log(`       ${row.url}`);
+  }
+}
+
+await writeFile(
+  join(ROOT, "migration-rollback.json"),
+  JSON.stringify(mapping, null, 2),
+);
+
+console.log(`\nmigrated ${ok}, failed ${failed}`);
+console.log(`rollback map: ${ROOT}/migration-rollback.json`);
+await pool.end();


### PR DESCRIPTION
- Upload photos instead of pasting URLs, for exec tiles, event posters and profiles
- Files go to a shared `brockcsc-uploads` Docker volume; random filenames and path-traversal guards on serving
- Executive Management (page and write APIs) now requires the co-president role
- Profile page rebuilt around a live preview of your real team page card

Existing images on images.brockcsc.ca are migrated separately.