### PR TITLE
Serve production from brockcsc.ca

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
           VPS_HOST="129-153-49-190.sslip.io"
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "env_name=production" >> "$GITHUB_OUTPUT"
-            echo "url=https://brockcsc.$VPS_HOST" >> "$GITHUB_OUTPUT"
+            echo "url=https://brockcsc.ca" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             echo "env_name=uat" >> "$GITHUB_OUTPUT"
             echo "url=https://uat.$VPS_HOST" >> "$GITHUB_OUTPUT"

--- a/komodo/deploy-context.mjs
+++ b/komodo/deploy-context.mjs
@@ -1,5 +1,8 @@
 import { appendFileSync } from "node:fs";
 
+// Production lives on the club domain; uat and previews stay on sslip.io so
+// they are not discoverable under brockcsc.ca (their DBs are copies of prod).
+const PROD_HOST = "brockcsc.ca";
 const VPS_HOST = "129-153-49-190.sslip.io";
 
 const slugify = (branch) =>
@@ -21,7 +24,7 @@ let branch;
 if (ref.startsWith("refs/tags/")) {
   branch = ref.slice("refs/tags/".length);
   projectName = "brockcsc-prod";
-  subdomain = `brockcsc.${VPS_HOST}`;
+  subdomain = PROD_HOST;
   dbSchema = "prod";
 } else if (ref === "refs/heads/main") {
   branch = "main";


### PR DESCRIPTION
Production now answers on the club domain. uat and previews stay on sslip.io deliberately — their databases are copies of prod, so they should not be discoverable under the public domain.