### PR TITLE
Reveal alumni and past events a term at a time

### DIFF
--- a/app/events/pageClient.tsx
+++ b/app/events/pageClient.tsx
@@ -2,6 +2,9 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import { useRevealedGroups } from "@/lib/use-revealed-groups";
+
 import { fetchAllEvents, type EventRecord, type WithKey } from "@/lib/api";
 import { classifyEventsByTiming } from "@/lib/events/classify";
 import { getEventStartTimestamp } from "@/lib/events/schedule";
@@ -124,8 +127,11 @@ export default function EventsPageClient() {
     return Array.from(groups.entries()).map(([term, events]) => ({
       term,
       events,
+      items: events,
     }));
   }, [past]);
+
+  const archive = useRevealedGroups(pastGroups);
 
   return (
     <main className="min-h-screen bg-white pb-10">
@@ -157,6 +163,26 @@ export default function EventsPageClient() {
               />
             ))}
           </div>
+        </section>
+      )}
+
+      {!loading && !error && ongoing.length === 0 && upcoming.length === 0 && (
+        <section className="mt-3 rounded-[16px] border-2 border-dashed border-border bg-white px-4 py-8 text-center">
+          <h2 className="m-0 font-semibold text-[1.35rem] leading-[1.1]">
+            Nothing on the calendar right now
+          </h2>
+          <p className="mx-auto mt-2 mb-4 max-w-[38rem] text-[0.9rem] text-muted-foreground">
+            We run workshops, socials and talks through the school year. Join
+            the Discord and you&apos;ll hear about the next one first.
+          </p>
+          <a
+            className="inline-flex items-center gap-2 rounded-[16px] border-2 border-black bg-[#9A4440] px-4 py-2 text-sm font-semibold text-white shadow-[3px_3px_0_0_#000]"
+            href="https://discord.gg/dsxEASYgRd"
+            rel="noreferrer"
+            target="_blank"
+          >
+            Join the Discord
+          </a>
         </section>
       )}
 
@@ -199,7 +225,7 @@ export default function EventsPageClient() {
         )}
 
         <div className="flex flex-col gap-4">
-          {pastGroups.map((group) => (
+          {archive.visible.map((group) => (
             <section key={group.term}>
               <h3 className="mb-2 text-base font-semibold text-foreground/80">
                 {group.term}
@@ -215,6 +241,17 @@ export default function EventsPageClient() {
               </div>
             </section>
           ))}
+
+          {archive.hasMore && (
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <Button onClick={archive.revealMore} variant="outline">
+                Show earlier events
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {archive.hidden} more
+              </span>
+            </div>
+          )}
         </div>
       </section>
     </main>

--- a/app/team/pageClient.tsx
+++ b/app/team/pageClient.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useRevealedGroups } from "@/lib/use-revealed-groups";
 
 import {
   fetchCurrentExecs,
@@ -101,9 +103,14 @@ export default function TeamPageClient() {
   const hasCurrentExecs = currentExecs.length > 0;
   const hasPreviousExecs = previousExecs.length > 0;
   const previousExecGroups = useMemo(
-    () => groupPreviousExecsByTerm(previousExecs),
+    () =>
+      groupPreviousExecsByTerm(previousExecs).map((group) => ({
+        ...group,
+        items: group.members,
+      })),
     [previousExecs],
   );
+  const alumni = useRevealedGroups(previousExecGroups);
   const errorMessage = error ? (
     <p className="mb-4 text-muted-foreground">{error}</p>
   ) : null;
@@ -165,7 +172,7 @@ export default function TeamPageClient() {
 
         {hasPreviousExecs && (
           <div className="flex flex-col gap-4">
-            {previousExecGroups.map((group) => (
+            {alumni.visible.map((group) => (
               <section key={group.term}>
                 <h3 className="mb-2 text-base font-semibold text-foreground/80">
                   {group.term}
@@ -181,6 +188,17 @@ export default function TeamPageClient() {
                 </div>
               </section>
             ))}
+
+            {alumni.hasMore && (
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <Button onClick={alumni.revealMore} variant="outline">
+                  Show earlier executives
+                </Button>
+                <span className="text-sm text-muted-foreground">
+                  {alumni.hidden} more
+                </span>
+              </div>
+            )}
           </div>
         )}
       </section>

--- a/lib/use-revealed-groups.ts
+++ b/lib/use-revealed-groups.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type Group<T> = { items: T[] };
+
+/**
+ * Reveals whole groups at a time, never splitting one across a click, and keeps
+ * going until at least `step` more items are shown. Stopping mid-term would read
+ * as broken rather than paginated.
+ */
+export const useRevealedGroups = <T, G extends Group<T>>(
+  groups: G[],
+  step = 10,
+) => {
+  const [revealed, setRevealed] = useState(1);
+
+  const boundaries = useMemo(() => {
+    const marks: number[] = [];
+    let sinceMark = 0;
+    groups.forEach((group, index) => {
+      sinceMark += group.items.length;
+      if (sinceMark >= step || index === groups.length - 1) {
+        marks.push(index + 1);
+        sinceMark = 0;
+      }
+    });
+    return marks.length ? marks : [groups.length];
+  }, [groups, step]);
+
+  const shownGroups =
+    boundaries[Math.min(revealed, boundaries.length) - 1] ?? 0;
+  const visible = groups.slice(0, shownGroups);
+  const hidden = groups
+    .slice(shownGroups)
+    .reduce((total, group) => total + group.items.length, 0);
+
+  return {
+    visible,
+    hidden,
+    hasMore: shownGroups < groups.length,
+    revealMore: () => setRevealed((n) => n + 1),
+    revealAll: () => setRevealed(boundaries.length),
+  };
+};


### PR DESCRIPTION
- /team loaded 46 alumni photos at once and /events loaded 102 past events; both now reveal whole terms until at least 10 more items are shown, so a click never cuts a term in half
- Shared hook so the two pages stay consistent
- Events page gains an empty state when nothing is ongoing or upcoming, pointing at the Discord