### PR TITLE
Replace the fake dashboard visit count with real stats

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,16 +1,82 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import Card from "@/components/ui/card";
 import { EventTimelineCard } from "../events/components/event-timeline-card";
-import { EventRecord, fetchFutureEvents, WithKey } from "@/lib/api";
+import {
+  DashboardStats,
+  EventRecord,
+  fetchDashboardStats,
+  fetchFutureEvents,
+  WithKey,
+} from "@/lib/api";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-export default function AdminPage() {
-  type EventItem = WithKey<EventRecord>;
+type EventItem = WithKey<EventRecord>;
+type Tone = "muted" | "up" | "down";
 
+const TONE_CLASS: Record<Tone, string> = {
+  muted: "text-neutral-500",
+  up: "text-green-600",
+  down: "text-[#d44b4b]",
+};
+
+const plural = (count: number, noun: string) =>
+  `${count} ${noun}${count === 1 ? "" : "s"}`;
+
+const viewsDetail = (
+  pageViews: DashboardStats["pageViews"],
+): { detail: string; tone: Tone } => {
+  const { last30Days, previous30Days } = pageViews;
+  if (previous30Days === 0) {
+    return { detail: "No previous 30 days to compare", tone: "muted" };
+  }
+  const change = Math.round(
+    ((last30Days - previous30Days) / previous30Days) * 100,
+  );
+  if (change === 0) {
+    return { detail: "Level with the previous 30 days", tone: "muted" };
+  }
+  return {
+    detail: `${change > 0 ? "↑ +" : "↓ "}${change}% vs previous 30 days`,
+    tone: change > 0 ? "up" : "down",
+  };
+};
+
+type StatCardProps = {
+  label: string;
+  value: string;
+  detail: string;
+  tone: Tone;
+  href?: string;
+};
+
+const StatCard = ({ label, value, detail, tone, href }: StatCardProps) => {
+  const card = (
+    <div className="h-full rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_#9A4440]">
+      <div className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+        {label}
+      </div>
+      <div className="my-1 text-3xl font-bold text-[#9A4440]">{value}</div>
+      <div className={`text-sm ${TONE_CLASS[tone]}`}>{detail}</div>
+    </div>
+  );
+
+  return href ? (
+    <Link
+      href={href}
+      className="block transition-transform hover:-translate-y-0.5"
+    >
+      {card}
+    </Link>
+  ) : (
+    card
+  );
+};
+
+export default function AdminPage() {
   const [futureEvents, setFutureEvents] = useState<EventItem[]>([]);
+  const [stats, setStats] = useState<DashboardStats | null>(null);
   const [nowTimestamp] = useState(() => Date.now());
 
   useEffect(() => {
@@ -18,16 +84,20 @@ export default function AdminPage() {
 
     const load = async () => {
       try {
-        const futureEventsRaw = await fetchFutureEvents();
+        const [events, dashboardStats] = await Promise.all([
+          fetchFutureEvents(),
+          fetchDashboardStats(),
+        ]);
         if (!active) {
           return;
         }
-        setFutureEvents(futureEventsRaw);
+        setFutureEvents(events);
+        setStats(dashboardStats);
       } catch {
         if (!active) {
           return;
         }
-        console.error("Error loading events:");
+        console.error("Error loading dashboard");
       }
     };
 
@@ -37,50 +107,73 @@ export default function AdminPage() {
     };
   }, []);
 
-  const adaptEventForDisplay = (event: EventItem) => ({
-    title: event.title,
-    date: event.schedule?.startDate,
-    time: event.schedule?.startTime,
-    location: event.location?.split(",")[0],
-    description: event.description,
-    image: event.image,
-  });
-
-  const events = futureEvents.map(adaptEventForDisplay);
+  const views = stats ? viewsDetail(stats.pageViews) : null;
+  const cards: StatCardProps[] = [
+    {
+      label: "Page views (30 days)",
+      value: stats ? stats.pageViews.last30Days.toLocaleString() : "—",
+      detail: views?.detail ?? "Loading",
+      tone: views?.tone ?? "muted",
+    },
+    {
+      label: "Executive team",
+      value: stats ? String(stats.execs.current) : "—",
+      detail: stats ? plural(stats.execs.past, "past member") : "Loading",
+      tone: "muted",
+    },
+    {
+      label: "Scheduled events",
+      value: stats ? String(stats.events.upcoming) : "—",
+      detail: stats ? plural(stats.events.past, "past event") : "Loading",
+      tone: "muted",
+      href: "/admin/events",
+    },
+    ...(stats && stats.pendingSignups !== null
+      ? [
+          {
+            label: "Pending sign-ups",
+            value: String(stats.pendingSignups),
+            detail:
+              stats.pendingSignups > 0
+                ? "Waiting on your review"
+                : "Nothing to review",
+            tone: (stats.pendingSignups > 0 ? "down" : "muted") as Tone,
+            href: "/admin/execs",
+          },
+        ]
+      : []),
+  ];
 
   return (
     <div>
-      <div className="mb-8">
+      <div className="mb-10">
         <h1 className="text-3xl font-bold mb-2">Admin Dashboard</h1>
         <p className="text-neutral-500 mb-6">Welcome back!</p>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 mb-8 gap-6">
-          <Card>
-            <div className="flex flex-col items-start w-full">
-              <span className="text-xs font-semibold text-neutral-500 mb-2">
-                WEBSITE VISITS
-              </span>
-              <span className="text-2xl font-bold mb-1">2.4k</span>
-              <span className="text-green-600 text-sm font-medium">
-                ↑ +12% this month
-              </span>
-            </div>
-          </Card>
-          <div className="flex flex-col gap-4 mb-10 h-full justify-center">
-            <Button asChild variant="primary" className="w-full md:w-auto">
-              <Link href="/admin/events">+ Create New Event</Link>
-            </Button>
-            <Button asChild variant="secondary" className="w-full md:w-auto">
-              <Link href="/admin/execs">+ Add New Executive</Link>
-            </Button>
-          </div>
+        <div
+          className={`grid grid-cols-1 gap-5 sm:grid-cols-2 ${
+            cards.length === 4 ? "lg:grid-cols-4" : "lg:grid-cols-3"
+          }`}
+        >
+          {cards.map((card) => (
+            <StatCard key={card.label} {...card} />
+          ))}
+        </div>
+
+        <div className="mt-6 flex flex-col gap-4 sm:flex-row">
+          <Button asChild variant="primary">
+            <Link href="/admin/events">+ Create New Event</Link>
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href="/admin/execs">+ Add New Executive</Link>
+          </Button>
         </div>
       </div>
 
       <div>
         <h1 className="text-3xl font-bold mb-2">Upcoming Events</h1>
         <p className="text-neutral-500 mb-6">Click to edit an event</p>
-        {events.length === 0 ? (
+        {futureEvents.length === 0 ? (
           <div className="text-center text-neutral-500 py-20">
             No upcoming events found.
           </div>

--- a/app/api/page-view/route.ts
+++ b/app/api/page-view/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { create } from "@/lib/db/repository";
+import { pageViewsTable } from "@/lib/db/schema";
+
+/** Admin traffic is the club's own work, so it is not a visit to the website. */
+const isPublicPath = (path: unknown): path is string =>
+  typeof path === "string" &&
+  path.startsWith("/") &&
+  path.length <= 200 &&
+  !path.startsWith("/admin");
+
+export const POST = async (req: NextRequest) => {
+  const body: unknown = await req.json().catch(() => null);
+  const path = (body as { path?: unknown } | null)?.path;
+  if (isPublicPath(path)) {
+    await create(pageViewsTable, { path });
+  }
+  return new NextResponse(null, { status: 204 });
+};

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,70 @@
+import { and, count, gte, lt } from "drizzle-orm";
+import { NextResponse, type NextRequest } from "next/server";
+import type {
+  DashboardStats,
+  EventRecord,
+  ExecRecord,
+  SignupRecord,
+} from "@/lib/api/types";
+import { requireAdmin, requireApprover } from "@/lib/auth/session";
+import { db } from "@/lib/db";
+import { findAll, toWireRecord } from "@/lib/db/repository";
+import {
+  eventsTable,
+  execsTable,
+  pageViewsTable,
+  signupsTable,
+} from "@/lib/db/schema";
+import { classifyEventsByTiming } from "@/lib/events/classify";
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+const countViews = async (fromMs: number, toMs: number): Promise<number> => {
+  const [row] = await db
+    .select({ total: count() })
+    .from(pageViewsTable)
+    .where(
+      and(
+        gte(pageViewsTable.createdAt, new Date(fromMs)),
+        lt(pageViewsTable.createdAt, new Date(toMs)),
+      ),
+    );
+  return row?.total ?? 0;
+};
+
+export const GET = async (req: NextRequest) => {
+  if (!(await requireAdmin(req))) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 401 });
+  }
+
+  const now = Date.now();
+  const [execs, events, last30Days, previous30Days, approver] =
+    await Promise.all([
+      findAll<ExecRecord>(execsTable),
+      findAll<EventRecord>(eventsTable),
+      countViews(now - THIRTY_DAYS_MS, now),
+      countViews(now - 2 * THIRTY_DAYS_MS, now - THIRTY_DAYS_MS),
+      requireApprover(req),
+    ]);
+
+  const timing = classifyEventsByTiming(events.map(toWireRecord), now);
+
+  const stats: DashboardStats = {
+    pageViews: { last30Days, previous30Days },
+    execs: {
+      current: execs.filter((exec) => exec.isCurrentExec === true).length,
+      past: execs.filter((exec) => exec.isCurrentExec === false).length,
+    },
+    events: {
+      upcoming: timing.upcoming.length + timing.ongoing.length,
+      past: timing.past.length,
+    },
+    pendingSignups: approver
+      ? (await findAll<SignupRecord>(signupsTable)).filter(
+          (signup) => signup.status === "pending",
+        ).length
+      : null,
+  };
+
+  return NextResponse.json(stats);
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/ui/navbar";
 import Footer from "@/components/ui/footer";
+import { PageViewTracker } from "@/components/page-view-tracker";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -40,6 +41,7 @@ export default function RootLayout({
           <div className="mx-auto w-full max-w-[1060px] px-5">{children}</div>
         </div>
         <Footer />
+        <PageViewTracker />
       </body>
     </html>
   );

--- a/components/page-view-tracker.tsx
+++ b/components/page-view-tracker.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import { recordPageView } from "@/lib/api";
+
+/**
+ * Records one view per rendered path. Only the path and a timestamp are stored,
+ * and a view that fails to record is simply lost rather than shown to the user.
+ */
+export function PageViewTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    recordPageView(pathname).catch(() => {});
+  }, [pathname]);
+
+  return null;
+}

--- a/drizzle/0002_uneven_azazel.sql
+++ b/drizzle/0002_uneven_azazel.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "page_views" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"data" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,151 @@
+{
+  "id": "a650248a-e595-47c2-a375-63bdb20113af",
+  "prevId": "7bcc9e50-df55-440c-b8f8-47d42f4989f0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.execs": {
+      "name": "execs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.page_views": {
+      "name": "page_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signups": {
+      "name": "signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1786577587759,
       "tag": "0001_boring_sasquatch",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786596476243,
+      "tag": "0002_uneven_azazel",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/api/index.ts
+++ b/lib/api/index.ts
@@ -18,9 +18,12 @@ export {
   reviewSignup,
   deleteSignup,
   fetchInviteCode,
+  fetchDashboardStats,
+  recordPageView,
 } from "./records";
 export { fetchCurrentUser, login, logout, signup } from "./auth";
 export type {
+  DashboardStats,
   EventRecord,
   ExecRecord,
   SessionUser,

--- a/lib/api/records.ts
+++ b/lib/api/records.ts
@@ -1,5 +1,11 @@
 import { apiFetch } from "./client";
-import type { EventRecord, ExecRecord, SignupRecord, WithKey } from "./types";
+import type {
+  DashboardStats,
+  EventRecord,
+  ExecRecord,
+  SignupRecord,
+  WithKey,
+} from "./types";
 import { getEventStartTimestamp, getEventTiming } from "@/lib/events/schedule";
 
 export const fetchAllExecs = async (): Promise<WithKey<ExecRecord>[]> =>
@@ -134,3 +140,14 @@ export const fetchInviteCode = async (): Promise<{
   code: string;
   expiresInMs: number;
 }> => apiFetch("/api/invite-code");
+
+export const fetchDashboardStats = async (): Promise<DashboardStats> =>
+  apiFetch<DashboardStats>("/api/stats");
+
+export const recordPageView = async (path: string): Promise<void> => {
+  await apiFetch("/api/page-view", {
+    method: "POST",
+    body: JSON.stringify({ path }),
+    keepalive: true,
+  });
+};

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -63,6 +63,14 @@ export type SignupRecord = {
   reviewedAt?: string;
 };
 
+export type DashboardStats = {
+  pageViews: { last30Days: number; previous30Days: number };
+  execs: { current: number; past: number };
+  events: { upcoming: number; past: number };
+  /** Null when the admin may not approve sign-ups. */
+  pendingSignups: number | null;
+};
+
 export type EventRecord = {
   title?: string;
   presenter?: string;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -12,3 +12,4 @@ const jsonbTable = (name: string) =>
 export const eventsTable = jsonbTable("events");
 export const execsTable = jsonbTable("execs");
 export const signupsTable = jsonbTable("signups");
+export const pageViewsTable = jsonbTable("page_views");


### PR DESCRIPTION
## What & why

The dashboard's "WEBSITE VISITS" tile was a hardcoded `2.4k` with a hardcoded `↑ +12% this month` — nothing wrote or read any visit data. This replaces it with a real number and adds stats that come from data already in the database.

- New `page_views` table (migration `0002_uneven_azazel.sql`, additive `CREATE TABLE`). A small client component in the root layout posts the path to `POST /api/page-view` once per rendered path; only the path and a timestamp are stored, and `/admin/*` is excluded server-side so the club's own work is not counted as a visit.
- New `GET /api/stats`, gated with `requireAdmin`: page views in the last 30 days plus the previous 30 for a real trend, current vs past executives, scheduled vs past events (via the existing `classifyEventsByTiming`), and pending sign-ups — the last only for `requireApprover`, `null` otherwise.
- Dashboard now renders a stat grid in the existing card style (rounded, black border, `#9A4440` shadow), with the events and sign-ups tiles linking to their management pages. Also drops some dead code (`adaptEventForDisplay`).

No new dependencies, no external network calls, no new env vars.

## How to test

1. `npm run db:up && npm run db:migrate`, then `npm run dev`.
2. Browse a few public pages (`/`, `/team`, `/events`) — each navigation records a row in `page_views`.
3. Sign in at `/admin` with an account holding the admin role: the dashboard shows page views for the last 30 days with a real comparison against the previous 30 (it reads "No previous 30 days to compare" on a fresh database), plus team, event and sign-up counts.
4. Visit `/admin` while logged in — the visit is not counted.
5. `curl -i localhost:3000/api/stats` without a session returns 401. With a non-approver admin session, `pendingSignups` is `null` and that tile is hidden.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [ ] `npm run build` passes (not run — another build was in flight)
- [x] New env vars added to `.env.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` (none needed)
- [x] Schema changes have a generated migration (`npm run db:generate`)
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover`
- [x] No secrets in committed files
