### PR TITLE
Drop the uploads-init job so stacks are not left unhealthy

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,29 +5,13 @@ networks:
     external: true
 
 services:
-  # The app runs as uid 1001; a named volume is created root-owned, so uploads
-  # would fail with EACCES without this.
-  uploads-init:
-    image: busybox:1.36
-    user: root
-    command:
-      [
-        "sh",
-        "-c",
-        "mkdir -p /data/uploads && chown -R 1001:65533 /data/uploads",
-      ]
-    volumes:
-      - uploads:/data/uploads
-    restart: "no"
-
+  # Uploads volume ownership comes from the image: the Dockerfile creates
+  # /data/uploads as nextjs:nodejs, which an empty volume inherits on first mount.
   app:
     image: brockcsc-ca:${IMAGE_TAG}
     pull_policy: never
     container_name: ${PROJECT_NAME}-app
     restart: unless-stopped
-    depends_on:
-      uploads-init:
-        condition: service_completed_successfully
     networks: [wayfarer-net]
     volumes:
       - uploads:/data/uploads


### PR DESCRIPTION
The one-shot `uploads-init` container sits in `Exited (0)` after every deploy,
which Komodo reads as an unhealthy stack.

It is also redundant: `Dockerfile` already creates `/data/uploads` owned by
`nextjs:nodejs`, and Docker copies image content and ownership into an empty
named volume on first mount, so a fresh volume comes up owned by uid 1001
without any help. The existing `brockcsc-uploads` volume was chowned by the
init job already and stays as it is.

Verified on the box: `/data/uploads` inside `brockcsc-prod-app` is owned by
1001, and the only `uploads-init` containers present are exited.