### PR TITLE
Make the dashboard stats actionable

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -124,9 +124,26 @@ export default function AdminPage() {
     {
       label: "Scheduled events",
       value: stats ? String(stats.events.upcoming) : "—",
-      detail: stats ? plural(stats.events.past, "past event") : "Loading",
-      tone: "muted",
+      detail: stats
+        ? stats.events.next
+          ? `Next: ${stats.events.next.title} in ${plural(stats.events.next.inDays, "day")}`
+          : "Nothing scheduled"
+        : "Loading",
+      tone: stats && !stats.events.next ? "down" : "muted",
       href: "/admin/events",
+    },
+    {
+      label: "Profiles to chase",
+      value: stats ? String(stats.execs.incompleteProfiles) : "—",
+      detail: stats
+        ? stats.execs.incompleteProfiles > 0
+          ? "Missing a photo or bio"
+          : "Every profile is complete"
+        : "Loading",
+      tone: (stats && stats.execs.incompleteProfiles > 0
+        ? "down"
+        : "muted") as Tone,
+      href: "/admin/execs",
     },
     ...(stats && stats.pendingSignups !== null
       ? [
@@ -142,6 +159,20 @@ export default function AdminPage() {
           },
         ]
       : []),
+    ...(stats && stats.unclaimedTiles !== null
+      ? [
+          {
+            label: "Tiles without a login",
+            value: String(stats.unclaimedTiles),
+            detail:
+              stats.unclaimedTiles > 0
+                ? "These execs cannot edit themselves"
+                : "Everyone can edit their own",
+            tone: (stats.unclaimedTiles > 0 ? "down" : "muted") as Tone,
+            href: "/admin/execs",
+          },
+        ]
+      : []),
   ];
 
   return (
@@ -150,15 +181,41 @@ export default function AdminPage() {
         <h1 className="text-3xl font-bold mb-2">Admin Dashboard</h1>
         <p className="text-neutral-500 mb-6">Welcome back!</p>
 
-        <div
-          className={`grid grid-cols-1 gap-5 sm:grid-cols-2 ${
-            cards.length === 4 ? "lg:grid-cols-4" : "lg:grid-cols-3"
-          }`}
-        >
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {cards.map((card) => (
             <StatCard key={card.label} {...card} />
           ))}
         </div>
+
+        {stats && stats.pageViews.topPaths.length > 0 && (
+          <section className="mt-6 rounded-2xl border-2 border-black bg-white p-5 shadow-[4px_4px_0px_#9A4440]">
+            <h2 className="text-sm font-bold uppercase tracking-wide">
+              Most visited pages
+            </h2>
+            <p className="mt-1 text-sm text-neutral-500">Last 30 days.</p>
+            <ul className="mt-4 flex flex-col gap-2">
+              {stats.pageViews.topPaths.map((entry) => {
+                const share = Math.round(
+                  (entry.views / stats.pageViews.topPaths[0].views) * 100,
+                );
+                return (
+                  <li className="flex items-center gap-3" key={entry.path}>
+                    <span className="w-40 shrink-0 truncate font-mono text-xs">
+                      {entry.path}
+                    </span>
+                    <span
+                      className="h-3 rounded-full bg-[#9A4440]"
+                      style={{ width: `${Math.max(share, 4)}%` }}
+                    />
+                    <span className="text-xs text-neutral-500">
+                      {entry.views.toLocaleString()}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
 
         <div className="mt-6 flex flex-col gap-4 sm:flex-row">
           <Button asChild variant="primary">

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,4 +1,4 @@
-import { and, count, gte, lt } from "drizzle-orm";
+import { and, count, desc, gte, lt, sql } from "drizzle-orm";
 import { NextResponse, type NextRequest } from "next/server";
 import type {
   DashboardStats,
@@ -16,6 +16,7 @@ import {
   signupsTable,
 } from "@/lib/db/schema";
 import { classifyEventsByTiming } from "@/lib/events/classify";
+import { getEventTiming } from "@/lib/events/schedule";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
@@ -32,37 +33,79 @@ const countViews = async (fromMs: number, toMs: number): Promise<number> => {
   return row?.total ?? 0;
 };
 
+/** The path column is recorded on every view; without this it is dead weight. */
+const topPaths = async (fromMs: number) => {
+  const path = sql<string>`${pageViewsTable.data}->>'path'`;
+  const rows = await db
+    .select({ path, views: count() })
+    .from(pageViewsTable)
+    .where(gte(pageViewsTable.createdAt, new Date(fromMs)))
+    .groupBy(path)
+    .orderBy(desc(count()))
+    .limit(5);
+  return rows.map((row) => ({ path: row.path ?? "/", views: row.views }));
+};
+
 export const GET = async (req: NextRequest) => {
   if (!(await requireAdmin(req))) {
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
 
   const now = Date.now();
-  const [execs, events, last30Days, previous30Days, approver] =
+  const [execs, events, last30Days, previous30Days, paths, approver] =
     await Promise.all([
       findAll<ExecRecord>(execsTable),
       findAll<EventRecord>(eventsTable),
       countViews(now - THIRTY_DAYS_MS, now),
       countViews(now - 2 * THIRTY_DAYS_MS, now - THIRTY_DAYS_MS),
+      topPaths(now - THIRTY_DAYS_MS),
       requireApprover(req),
     ]);
 
   const timing = classifyEventsByTiming(events.map(toWireRecord), now);
+  const currentExecs = execs.filter((exec) => exec.isCurrentExec === true);
+
+  const nextStart = [...timing.upcoming, ...timing.ongoing]
+    .map((event) => ({
+      title: event.title ?? "Untitled event",
+      startsAt: getEventTiming(event, now).nextStartTimestamp,
+    }))
+    .filter(
+      (entry): entry is { title: string; startsAt: number } =>
+        typeof entry.startsAt === "number",
+    )
+    .sort((a, b) => a.startsAt - b.startsAt)[0];
+
+  const signups = approver ? await findAll<SignupRecord>(signupsTable) : [];
+  const linkedKeys = new Set(signups.map((signup) => signup.execKey));
 
   const stats: DashboardStats = {
-    pageViews: { last30Days, previous30Days },
+    pageViews: { last30Days, previous30Days, topPaths: paths },
     execs: {
-      current: execs.filter((exec) => exec.isCurrentExec === true).length,
+      current: currentExecs.length,
       past: execs.filter((exec) => exec.isCurrentExec === false).length,
+      incompleteProfiles: currentExecs.filter(
+        (exec) => !exec.image?.url || !exec.description?.trim(),
+      ).length,
     },
     events: {
       upcoming: timing.upcoming.length + timing.ongoing.length,
       past: timing.past.length,
+      next: nextStart
+        ? {
+            title: nextStart.title,
+            inDays: Math.max(
+              0,
+              Math.round((nextStart.startsAt - now) / (24 * 60 * 60 * 1000)),
+            ),
+          }
+        : null,
     },
     pendingSignups: approver
-      ? (await findAll<SignupRecord>(signupsTable)).filter(
-          (signup) => signup.status === "pending",
-        ).length
+      ? signups.filter((signup) => signup.status === "pending").length
+      : null,
+    unclaimedTiles: approver
+      ? currentExecs.filter((exec) => !linkedKeys.has(exec.id)).length
       : null,
   };
 

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -64,11 +64,26 @@ export type SignupRecord = {
 };
 
 export type DashboardStats = {
-  pageViews: { last30Days: number; previous30Days: number };
-  execs: { current: number; past: number };
-  events: { upcoming: number; past: number };
+  pageViews: {
+    last30Days: number;
+    previous30Days: number;
+    topPaths: { path: string; views: number }[];
+  };
+  execs: {
+    current: number;
+    past: number;
+    /** Current execs with no photo or no bio — the chase list. */
+    incompleteProfiles: number;
+  };
+  events: {
+    upcoming: number;
+    past: number;
+    next: { title: string; inDays: number } | null;
+  };
   /** Null when the admin may not approve sign-ups. */
   pendingSignups: number | null;
+  /** Current execs with no login account. Null for non-approvers. */
+  unclaimedTiles: number | null;
 };
 
 export type EventRecord = {


### PR DESCRIPTION
The dashboard counted things without telling you to do anything. Adds:

- Most visited pages — we already record a path on every view and never used it
- Next event, with a countdown, instead of just an upcoming count
- Profiles to chase: current execs missing a photo or bio
- Tiles without a login: current execs who cannot edit themselves (approver only)