### PR TITLE
Verify sign-ups with Brock credentials; grant roles from the claimed title

### DIFF
--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -212,6 +212,12 @@ export default function ExecutivesManagementPage() {
 
         <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm text-neutral-600">
           {signup.email && <span className="break-all">{signup.email}</span>}
+          {signup.studentId && <span>#{signup.studentId}</span>}
+          {signup.isFormerExec && (
+            <span className="font-semibold text-neutral-500">
+              Former executive
+            </span>
+          )}
           {signup.phone && <span>{signup.phone}</span>}
           {signup.submittedAt && (
             <span>{new Date(signup.submittedAt).toLocaleDateString()}</span>

--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -41,6 +41,10 @@ const humanise = (ms: number): string => {
   return "under a minute";
 };
 
+/** Kept in step with APPROVER_TITLES in app/api/signups/[id]/route.ts. */
+const grantsApproval = (title?: string) =>
+  ["co-president", "president"].includes(title?.trim().toLowerCase() ?? "");
+
 const fullName = (signup: Signup) =>
   [signup.firstName, signup.lastName].filter(Boolean).join(" ");
 
@@ -244,6 +248,12 @@ export default function ExecutivesManagementPage() {
                   {match.name}
                   {match.title ? ` — ${match.title}` : ""}
                 </strong>
+                {grantsApproval(match.title) && (
+                  <span className="mt-1 block font-semibold text-[#d44b4b]">
+                    Approving also grants approval rights. Check the
+                    confirmation code with them first.
+                  </span>
+                )}
               </span>
             )}
           </div>

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -12,6 +12,8 @@ import { create } from "@/lib/db/repository";
 import { signupsTable } from "@/lib/db/schema";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const BROCK_EMAIL_PATTERN = /@(?:[a-z0-9-]+\.)*brocku\.ca$/i;
+const STUDENT_ID_PATTERN = /^\d{6,10}$/;
 
 const badRequest = (error: string) =>
   NextResponse.json({ error }, { status: 400 });
@@ -32,6 +34,8 @@ export const POST = async (req: NextRequest) => {
   const lastName = body.lastName?.trim() ?? "";
   const email = body.email?.trim() ?? "";
   const phone = body.phone?.trim() ?? "";
+  const studentId = body.studentId?.trim() ?? "";
+  const isFormerExec = String(body.isFormerExec) === "true";
   const password = body.password ?? "";
 
   if (!isValidInviteCode(inviteCode)) {
@@ -45,6 +49,19 @@ export const POST = async (req: NextRequest) => {
   }
   if (!EMAIL_PATTERN.test(email)) {
     return badRequest("Enter a valid email address.");
+  }
+  // Current execs verify with Brock credentials; alumni no longer have them.
+  if (!isFormerExec) {
+    if (!BROCK_EMAIL_PATTERN.test(email)) {
+      return badRequest(
+        "Use your @brocku.ca email, or tick that you are a former executive.",
+      );
+    }
+    if (!STUDENT_ID_PATTERN.test(studentId)) {
+      return badRequest("Enter your student number, digits only.");
+    }
+  } else if (studentId && !STUDENT_ID_PATTERN.test(studentId)) {
+    return badRequest("That student number does not look right.");
   }
   if (password.length < 8) {
     return badRequest("Password must be at least 8 characters.");
@@ -79,6 +96,8 @@ export const POST = async (req: NextRequest) => {
       username,
       email,
       phone: phone || undefined,
+      studentId: studentId || undefined,
+      isFormerExec,
       keycloakUserId,
       confirmationCode: confirmation,
       status: "pending",

--- a/app/api/signups/[id]/route.ts
+++ b/app/api/signups/[id]/route.ts
@@ -16,6 +16,17 @@ import {
 } from "@/lib/db/repository";
 import { execsTable, signupsTable } from "@/lib/db/schema";
 
+/**
+ * Titles that carry approval rights. The approval card shows the claimed title
+ * before you approve, so granting from it is visible rather than implicit.
+ */
+const APPROVER_TITLES = new Set(["co-president", "president"]);
+
+const roleForTitle = (title?: string) =>
+  APPROVER_TITLES.has(title?.trim().toLowerCase() ?? "")
+    ? "co-president"
+    : null;
+
 export const PATCH = async (
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -50,26 +61,41 @@ export const PATCH = async (
       );
     }
     await setUserEnabled(signup.keycloakUserId, true);
-    await assignRealmRole(
-      signup.keycloakUserId,
-      process.env.ADMIN_ROLE ?? "executive",
-    );
   } else if (signup.keycloakUserId) {
     await deleteUser(signup.keycloakUserId);
   }
 
   let execKey = signup.execKey;
-  if (action === "approve" && !execKey) {
-    const match = await findExecMatchingName(signup.firstName, signup.lastName);
-    if (match && !match.claimed) {
-      execKey = match.execKey;
+  let execTitle: string | undefined;
+  if (action === "approve") {
+    if (!execKey) {
+      const match = await findExecMatchingName(
+        signup.firstName,
+        signup.lastName,
+      );
+      if (match && !match.claimed) {
+        execKey = match.execKey;
+        execTitle = match.title;
+      } else {
+        const created = await create<ExecRecord>(execsTable, {
+          name: [signup.firstName, signup.lastName].filter(Boolean).join(" "),
+          title: "Executive",
+          isCurrentExec: true,
+        });
+        execKey = created.id;
+        execTitle = created.title;
+      }
     } else {
-      const created = await create<ExecRecord>(execsTable, {
-        name: [signup.firstName, signup.lastName].filter(Boolean).join(" "),
-        title: "Executive",
-        isCurrentExec: true,
-      });
-      execKey = created.id;
+      execTitle = (await findById<ExecRecord>(execsTable, execKey))?.title;
+    }
+
+    await assignRealmRole(
+      signup.keycloakUserId!,
+      process.env.ADMIN_ROLE ?? "executive",
+    );
+    const extra = roleForTitle(execTitle);
+    if (extra) {
+      await assignRealmRole(signup.keycloakUserId!, extra);
     }
   }
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -38,6 +38,8 @@ export default function SignupPage() {
     lastName: "",
     email: "",
     phone: "",
+    studentId: "",
+    isFormerExec: false,
     password: "",
     confirmPassword: "",
   });
@@ -48,6 +50,8 @@ export default function SignupPage() {
   const set =
     (key: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
       setForm((prev) => ({ ...prev, [key]: e.target.value }));
+
+  const former = form.isFormerExec;
 
   const username = usernameFor(form.firstName, form.lastName);
 
@@ -147,13 +151,44 @@ export default function SignupPage() {
               </p>
             )}
 
+            <label className="mb-4 flex items-start gap-2 text-sm">
+              <input
+                checked={former}
+                className="mt-1"
+                onChange={(e) =>
+                  setForm((prev) => ({
+                    ...prev,
+                    isFormerExec: e.target.checked,
+                  }))
+                }
+                type="checkbox"
+              />
+              <span>
+                I&apos;m a former executive
+                <span className="block text-neutral-500">
+                  Alumni no longer have a Brock email or student number, so
+                  those become optional.
+                </span>
+              </span>
+            </label>
+
             <Field
               id="email"
-              label="Email"
+              label={former ? "Email" : "Brock email"}
               type="email"
+              placeholder={former ? undefined : "you@brocku.ca"}
               value={form.email}
               onChange={set("email")}
               required
+            />
+            <Field
+              id="studentId"
+              label="Student number"
+              inputMode="numeric"
+              optional={former}
+              value={form.studentId}
+              onChange={set("studentId")}
+              required={!former}
             />
             <Field
               id="phone"

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -40,6 +40,8 @@ export type SignupInput = {
   lastName: string;
   email: string;
   phone: string;
+  studentId: string;
+  isFormerExec: boolean;
   password: string;
   confirmPassword: string;
 };
@@ -52,6 +54,9 @@ export type SignupRecord = {
   username?: string;
   email?: string;
   phone?: string;
+  studentId?: string;
+  /** Alumni have no Brock email or student number any more. */
+  isFormerExec?: boolean;
   keycloakUserId?: string;
   /** Shown once at sign-up; the approver checks it out-of-band. */
   confirmationCode?: string;


### PR DESCRIPTION
- Sign-up now requires a @brocku.ca email and student number, unless "I'm a former executive" is ticked — alumni no longer have either
- Validation is enforced server side, not just on the form
- Approval grants co-president when the claimed tile is a president-level title, so approving Brennan gives him Executive Management without a manual Keycloak step
- The approval card warns when a claim carries approval rights