### PR TITLE
Let past executives see the dashboard

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -7,7 +7,7 @@ import Link from "next/link";
 import { LoginForm } from "@/components/admin/login-form";
 
 const adminTabs = [
-  { name: "Dashboard", href: "/admin", executiveOnly: true },
+  { name: "Dashboard", href: "/admin" },
   { name: "Events Management", href: "/admin/events", executiveOnly: true },
   { name: "Executives Management", href: "/admin/execs", approverOnly: true },
   { name: "My Profile", href: "/admin/profile" },
@@ -40,13 +40,6 @@ export default function AdminLayout({
       cancelled = true;
     };
   }, []);
-
-  // Alumni may only edit their own tile; other admin pages would just 401.
-  useEffect(() => {
-    if (!loading && authenticated && !isExecutive && !isApprover) {
-      if (pathname !== "/admin/profile") router.replace("/admin/profile");
-    }
-  }, [loading, authenticated, isExecutive, isApprover, pathname, router]);
 
   const handleLogout = async () => {
     try {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -132,19 +132,22 @@ export default function AdminPage() {
       tone: stats && !stats.events.next ? "down" : "muted",
       href: "/admin/events",
     },
-    {
-      label: "Profiles to chase",
-      value: stats ? String(stats.execs.incompleteProfiles) : "—",
-      detail: stats
-        ? stats.execs.incompleteProfiles > 0
-          ? "Missing a photo or bio"
-          : "Every profile is complete"
-        : "Loading",
-      tone: (stats && stats.execs.incompleteProfiles > 0
-        ? "down"
-        : "muted") as Tone,
-      href: "/admin/execs",
-    },
+    ...(stats && stats.pendingSignups !== null
+      ? [
+          {
+            label: "Profiles to chase",
+            value: String(stats.execs.incompleteProfiles),
+            detail:
+              stats.execs.incompleteProfiles > 0
+                ? "Missing a photo or bio"
+                : "Every profile is complete",
+            tone: (stats.execs.incompleteProfiles > 0
+              ? "down"
+              : "muted") as Tone,
+            href: "/admin/execs",
+          },
+        ]
+      : []),
     ...(stats && stats.pendingSignups !== null
       ? [
           {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -6,7 +6,7 @@ import type {
   ExecRecord,
   SignupRecord,
 } from "@/lib/api/types";
-import { requireAdmin, requireApprover } from "@/lib/auth/session";
+import { requireApprover, requireMember } from "@/lib/auth/session";
 import { db } from "@/lib/db";
 import { findAll, toWireRecord } from "@/lib/db/repository";
 import {
@@ -47,7 +47,7 @@ const topPaths = async (fromMs: number) => {
 };
 
 export const GET = async (req: NextRequest) => {
-  if (!(await requireAdmin(req))) {
+  if (!(await requireMember(req))) {
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
 


### PR DESCRIPTION
Alumni keep admin access to the Dashboard and My Profile. Events Management and Executive Management stay executive/approver only. Removes the redirect that bounced them straight to their profile.