### PR TITLE
Close gaps found in a security review

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { exchangeCredentials } from "@/lib/auth/keycloak";
 import { rateLimit } from "@/lib/rate-limit";
+import { badJson, jsonObject } from "@/lib/json";
 import {
   sessionCookieOptions,
   signSession,
@@ -17,10 +18,9 @@ export const POST = async (req: NextRequest) => {
   const limited = rateLimit(req, "login", 10, 15 * 60 * 1000);
   if (limited) return limited;
 
-  const { username, password } = (await req.json()) as {
-    username?: string;
-    password?: string;
-  };
+  const body = await jsonObject<{ username?: string; password?: string }>(req);
+  if (!body) return badJson();
+  const { username, password } = body;
 
   if (!username || !password) {
     return NextResponse.json(

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -29,6 +29,17 @@ export const POST = async (req: NextRequest) => {
     );
   }
 
+  // The per-IP cap alone does nothing against one account guessed from many
+  // addresses. Set above it, so a campus NAT hits the IP cap first.
+  const guessed = rateLimit(
+    req,
+    "login-user",
+    30,
+    15 * 60 * 1000,
+    username.toLowerCase(),
+  );
+  if (guessed) return guessed;
+
   const identity = await exchangeCredentials(username, password);
   if (!identity) {
     return NextResponse.json(

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { exchangeCredentials } from "@/lib/auth/keycloak";
+import { rateLimit } from "@/lib/rate-limit";
 import {
   sessionCookieOptions,
   signSession,
@@ -13,6 +14,9 @@ const {
 } = process.env;
 
 export const POST = async (req: NextRequest) => {
+  const limited = rateLimit(req, "login", 10, 15 * 60 * 1000);
+  if (limited) return limited;
+
   const { username, password } = (await req.json()) as {
     username?: string;
     password?: string;

--- a/app/api/execs/[id]/route.ts
+++ b/app/api/execs/[id]/route.ts
@@ -8,6 +8,7 @@ import {
   update,
 } from "@/lib/db/repository";
 import { asBool, cleanExec } from "@/lib/execs/patch";
+import { badJson, jsonObject } from "@/lib/json";
 import { execsTable, signupsTable } from "@/lib/db/schema";
 import type { ExecRecord, SignupRecord } from "@/lib/api/types";
 
@@ -32,7 +33,8 @@ export const PATCH = async (
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
   const { id } = await params;
-  const body = (await req.json()) as ExecRecord;
+  const body = await jsonObject<ExecRecord>(req);
+  if (!body) return badJson();
   const cleaned = cleanExec(body);
   if ("error" in cleaned) {
     return NextResponse.json({ error: cleaned.error }, { status: 400 });

--- a/app/api/execs/[id]/route.ts
+++ b/app/api/execs/[id]/route.ts
@@ -7,6 +7,7 @@ import {
   toWireRecord,
   update,
 } from "@/lib/db/repository";
+import { asBool, cleanExec } from "@/lib/execs/patch";
 import { execsTable, signupsTable } from "@/lib/db/schema";
 import type { ExecRecord, SignupRecord } from "@/lib/api/types";
 
@@ -31,8 +32,17 @@ export const PATCH = async (
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
   const { id } = await params;
-  const patch = (await req.json()) as Partial<ExecRecord>;
-  const entity = await update<ExecRecord>(execsTable, id, patch);
+  const body = (await req.json()) as ExecRecord;
+  const cleaned = cleanExec(body);
+  if ("error" in cleaned) {
+    return NextResponse.json({ error: cleaned.error }, { status: 400 });
+  }
+  const entity = await update<ExecRecord>(execsTable, id, {
+    ...cleaned.patch,
+    name: body.name,
+    title: body.title,
+    isCurrentExec: asBool(body.isCurrentExec),
+  });
   if (!entity) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/app/api/execs/[id]/route.ts
+++ b/app/api/execs/[id]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { requireApprover } from "@/lib/auth/session";
+import { requireApprover, requireMember } from "@/lib/auth/session";
 import {
-  createItemHandlers,
   findAll,
+  findById,
   remove,
   toWireRecord,
   update,
@@ -10,7 +10,18 @@ import {
 import { execsTable, signupsTable } from "@/lib/db/schema";
 import type { ExecRecord, SignupRecord } from "@/lib/api/types";
 
-export const { GET } = createItemHandlers<ExecRecord>(execsTable);
+/** A hidden tile reads as absent to the public, same as the collection route. */
+export const GET = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const { id } = await params;
+  const exec = await findById<ExecRecord>(execsTable, id);
+  if (!exec || (exec.hidden && !(await requireMember(req)))) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(toWireRecord(exec));
+};
 
 export const PATCH = async (
   req: NextRequest,

--- a/app/api/execs/route.ts
+++ b/app/api/execs/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { requireApprover, requireMember } from "@/lib/auth/session";
 import { create, findAll, toWireRecord } from "@/lib/db/repository";
 import { asBool, cleanExec } from "@/lib/execs/patch";
+import { badJson, jsonObject } from "@/lib/json";
 import { execsTable } from "@/lib/db/schema";
 import type { ExecRecord } from "@/lib/api/types";
 
@@ -21,7 +22,8 @@ export const POST = async (req: NextRequest) => {
   if (!(await requireApprover(req))) {
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
-  const body = (await req.json()) as ExecRecord;
+  const body = await jsonObject<ExecRecord>(req);
+  if (!body) return badJson();
   const cleaned = cleanExec(body);
   if ("error" in cleaned) {
     return NextResponse.json({ error: cleaned.error }, { status: 400 });

--- a/app/api/execs/route.ts
+++ b/app/api/execs/route.ts
@@ -1,14 +1,20 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { requireApprover } from "@/lib/auth/session";
-import {
-  create,
-  createCollectionHandlers,
-  toWireRecord,
-} from "@/lib/db/repository";
+import { requireApprover, requireMember } from "@/lib/auth/session";
+import { create, findAll, toWireRecord } from "@/lib/db/repository";
 import { execsTable } from "@/lib/db/schema";
 import type { ExecRecord } from "@/lib/api/types";
 
-export const { GET } = createCollectionHandlers<ExecRecord>(execsTable);
+/**
+ * Hiding a tile has to hold at the API, not just on the team page: this route
+ * is public, so filtering in the browser would leave the record a curl away.
+ */
+export const GET = async (req: NextRequest) => {
+  const execs = await findAll<ExecRecord>(execsTable);
+  const visible = (await requireMember(req))
+    ? execs
+    : execs.filter((exec) => !exec.hidden);
+  return NextResponse.json(visible.map(toWireRecord));
+};
 
 export const POST = async (req: NextRequest) => {
   if (!(await requireApprover(req))) {

--- a/app/api/execs/route.ts
+++ b/app/api/execs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { requireApprover, requireMember } from "@/lib/auth/session";
 import { create, findAll, toWireRecord } from "@/lib/db/repository";
+import { asBool, cleanExec } from "@/lib/execs/patch";
 import { execsTable } from "@/lib/db/schema";
 import type { ExecRecord } from "@/lib/api/types";
 
@@ -20,7 +21,17 @@ export const POST = async (req: NextRequest) => {
   if (!(await requireApprover(req))) {
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
-  const input = (await req.json()) as ExecRecord;
+  const body = (await req.json()) as ExecRecord;
+  const cleaned = cleanExec(body);
+  if ("error" in cleaned) {
+    return NextResponse.json({ error: cleaned.error }, { status: 400 });
+  }
+  const input: ExecRecord = {
+    ...cleaned.patch,
+    name: body.name,
+    title: body.title,
+    isCurrentExec: asBool(body.isCurrentExec),
+  };
   return NextResponse.json(
     toWireRecord(await create<ExecRecord>(execsTable, input)),
     {

--- a/app/api/page-view/route.ts
+++ b/app/api/page-view/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { create } from "@/lib/db/repository";
+import { rateLimit } from "@/lib/rate-limit";
 import { pageViewsTable } from "@/lib/db/schema";
 
 /** Admin traffic is the club's own work, so it is not a visit to the website. */
@@ -10,6 +11,11 @@ const isPublicPath = (path: unknown): path is string =>
   !path.startsWith("/admin");
 
 export const POST = async (req: NextRequest) => {
+  // The count is a vanity metric, but the table it writes to is not free.
+  if (rateLimit(req, "page-view", 60, 60 * 1000)) {
+    return new NextResponse(null, { status: 204 });
+  }
+
   const body: unknown = await req.json().catch(() => null);
   const path = (body as { path?: unknown } | null)?.path;
   if (isPublicPath(path)) {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -58,7 +58,8 @@ export const PATCH = async (req: NextRequest) => {
     description: body.description,
     term: body.term,
     socials: sanitiseSocials(body.socials),
-    image: {
+    // Left untouched when absent, so a partial patch cannot clear the photo.
+    image: body.image && {
       url,
       position: OBJECT_POSITION.test(position) ? position : "50% 50%",
     },

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -7,6 +7,11 @@ import { sanitiseSocials } from "@/lib/execs/socials";
 import { isValidTerm } from "@/lib/execs/terms";
 import { execsTable } from "@/lib/db/schema";
 
+const MAX_DESCRIPTION = 2000;
+/** Only images this app stored: an arbitrary URL here loads on the team page. */
+const UPLOAD_URL = /^\/uploads\/[A-Za-z0-9/._-]+$/;
+const OBJECT_POSITION = /^\d{1,3}(?:\.\d+)?% \d{1,3}(?:\.\d+)?%$/;
+
 const unauthorized = () =>
   NextResponse.json({ error: "Not authorized" }, { status: 401 });
 
@@ -34,12 +39,31 @@ export const PATCH = async (req: NextRequest) => {
   if (body.term && !isValidTerm(body.term)) {
     return NextResponse.json({ error: "Unknown term." }, { status: 400 });
   }
+  if ((body.description?.length ?? 0) > MAX_DESCRIPTION) {
+    return NextResponse.json(
+      { error: "That bio is too long." },
+      { status: 400 },
+    );
+  }
+  const url = body.image?.url?.trim() ?? "";
+  if (url && !UPLOAD_URL.test(url)) {
+    return NextResponse.json(
+      { error: "Photos must be uploaded here rather than linked." },
+      { status: 400 },
+    );
+  }
+  const position = body.image?.position ?? "";
+
   const exec = await update<ExecRecord>(execsTable, signup.execKey, {
     description: body.description,
     term: body.term,
     socials: sanitiseSocials(body.socials),
-    image: body.image,
-    hidden: body.hidden,
+    image: {
+      url,
+      position: OBJECT_POSITION.test(position) ? position : "50% 50%",
+    },
+    // Coerced: this now decides what the public API returns.
+    hidden: body.hidden === undefined ? undefined : body.hidden === true,
   });
   if (!exec) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -4,6 +4,7 @@ import { requireMember } from "@/lib/auth/session";
 import { findById, toWireRecord, update } from "@/lib/db/repository";
 import { findSignupByUserId } from "@/lib/db/signups";
 import { cleanExec } from "@/lib/execs/patch";
+import { badJson, jsonObject } from "@/lib/json";
 import { execsTable } from "@/lib/db/schema";
 
 const unauthorized = () =>
@@ -29,7 +30,8 @@ export const PATCH = async (req: NextRequest) => {
     return NextResponse.json({ error: "No linked profile" }, { status: 404 });
   }
 
-  const body = (await req.json()) as ExecRecord;
+  const body = await jsonObject<ExecRecord>(req);
+  if (!body) return badJson();
   // Only the fields cleanExec returns: name, title and isCurrentExec are the
   // approver's to set, not the exec's own.
   const cleaned = cleanExec(body);

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -3,14 +3,8 @@ import type { ExecRecord } from "@/lib/api/types";
 import { requireMember } from "@/lib/auth/session";
 import { findById, toWireRecord, update } from "@/lib/db/repository";
 import { findSignupByUserId } from "@/lib/db/signups";
-import { sanitiseSocials } from "@/lib/execs/socials";
-import { isValidTerm } from "@/lib/execs/terms";
+import { cleanExec } from "@/lib/execs/patch";
 import { execsTable } from "@/lib/db/schema";
-
-const MAX_DESCRIPTION = 2000;
-/** Only images this app stored: an arbitrary URL here loads on the team page. */
-const UPLOAD_URL = /^\/uploads\/[A-Za-z0-9/._-]+$/;
-const OBJECT_POSITION = /^\d{1,3}(?:\.\d+)?% \d{1,3}(?:\.\d+)?%$/;
 
 const unauthorized = () =>
   NextResponse.json({ error: "Not authorized" }, { status: 401 });
@@ -36,36 +30,18 @@ export const PATCH = async (req: NextRequest) => {
   }
 
   const body = (await req.json()) as ExecRecord;
-  if (body.term && !isValidTerm(body.term)) {
-    return NextResponse.json({ error: "Unknown term." }, { status: 400 });
+  // Only the fields cleanExec returns: name, title and isCurrentExec are the
+  // approver's to set, not the exec's own.
+  const cleaned = cleanExec(body);
+  if ("error" in cleaned) {
+    return NextResponse.json({ error: cleaned.error }, { status: 400 });
   }
-  if ((body.description?.length ?? 0) > MAX_DESCRIPTION) {
-    return NextResponse.json(
-      { error: "That bio is too long." },
-      { status: 400 },
-    );
-  }
-  const url = body.image?.url?.trim() ?? "";
-  if (url && !UPLOAD_URL.test(url)) {
-    return NextResponse.json(
-      { error: "Photos must be uploaded here rather than linked." },
-      { status: 400 },
-    );
-  }
-  const position = body.image?.position ?? "";
 
-  const exec = await update<ExecRecord>(execsTable, signup.execKey, {
-    description: body.description,
-    term: body.term,
-    socials: sanitiseSocials(body.socials),
-    // Left untouched when absent, so a partial patch cannot clear the photo.
-    image: body.image && {
-      url,
-      position: OBJECT_POSITION.test(position) ? position : "50% 50%",
-    },
-    // Coerced: this now decides what the public API returns.
-    hidden: body.hidden === undefined ? undefined : body.hidden === true,
-  });
+  const exec = await update<ExecRecord>(
+    execsTable,
+    signup.execKey,
+    cleaned.patch,
+  );
   if (!exec) {
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -9,11 +9,15 @@ import {
   usernameFor,
 } from "@/lib/auth/keycloak-admin";
 import { create } from "@/lib/db/repository";
+import { rateLimit } from "@/lib/rate-limit";
 import { signupsTable } from "@/lib/db/schema";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const BROCK_EMAIL_PATTERN = /@(?:[a-z0-9-]+\.)*brocku\.ca$/i;
 const STUDENT_ID_PATTERN = /^\d{6,10}$/;
+const MAX_NAME = 60;
+const MAX_EMAIL = 200;
+const MAX_PHONE = 30;
 
 const badRequest = (error: string) =>
   NextResponse.json({ error }, { status: 400 });
@@ -28,6 +32,10 @@ const confirmationCode = () =>
   ).join("");
 
 export const POST = async (req: NextRequest) => {
+  // Every accepted request creates a Keycloak account, so cap the burst.
+  const flooding = rateLimit(req, "signup", 20, 60 * 60 * 1000);
+  if (flooding) return flooding;
+
   const body = (await req.json()) as Record<string, string | undefined>;
   const inviteCode = body.inviteCode?.trim() ?? "";
   const firstName = body.firstName?.trim() ?? "";
@@ -39,16 +47,26 @@ export const POST = async (req: NextRequest) => {
   const password = body.password ?? "";
 
   if (!isValidInviteCode(inviteCode)) {
-    return NextResponse.json(
-      { error: "That invite code is not valid." },
-      { status: 403 },
+    // A wrong code is the only signal a guesser gets; make guesses expensive.
+    return (
+      rateLimit(req, "invite-code", 10, 60 * 60 * 1000) ??
+      NextResponse.json(
+        { error: "That invite code is not valid." },
+        { status: 403 },
+      )
     );
   }
   if (!firstName || !lastName) {
     return badRequest("First and last name are required.");
   }
-  if (!EMAIL_PATTERN.test(email)) {
+  if (firstName.length > MAX_NAME || lastName.length > MAX_NAME) {
+    return badRequest("That name is too long.");
+  }
+  if (email.length > MAX_EMAIL || !EMAIL_PATTERN.test(email)) {
     return badRequest("Enter a valid email address.");
+  }
+  if (phone.length > MAX_PHONE) {
+    return badRequest("That phone number is too long.");
   }
   // Current execs verify with Brock credentials; alumni no longer have them.
   if (!isFormerExec) {

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/auth/keycloak-admin";
 import { create } from "@/lib/db/repository";
 import { rateLimit } from "@/lib/rate-limit";
+import { badJson, jsonObject } from "@/lib/json";
 import { signupsTable } from "@/lib/db/schema";
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -36,7 +37,8 @@ export const POST = async (req: NextRequest) => {
   const flooding = rateLimit(req, "signup", 20, 60 * 60 * 1000);
   if (flooding) return flooding;
 
-  const body = (await req.json()) as Record<string, string | undefined>;
+  const body = await jsonObject<Record<string, string | undefined>>(req);
+  if (!body) return badJson();
   const inviteCode = body.inviteCode?.trim() ?? "";
   const firstName = body.firstName?.trim() ?? "";
   const lastName = body.lastName?.trim() ?? "";

--- a/app/api/signups/[id]/route.ts
+++ b/app/api/signups/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   setUserEnabled,
 } from "@/lib/auth/keycloak-admin";
 import { requireApprover } from "@/lib/auth/session";
+import { badJson, jsonObject } from "@/lib/json";
 import { findExecMatchingName } from "@/lib/db/execs";
 import { grantsApproval } from "@/lib/execs/titles";
 import {
@@ -26,7 +27,9 @@ export const PATCH = async (
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
 
-  const { action } = (await req.json()) as { action?: string };
+  const body = await jsonObject<{ action?: string }>(req);
+  if (!body) return badJson();
+  const { action } = body;
   if (action !== "approve" && action !== "reject") {
     return NextResponse.json({ error: "Unknown action" }, { status: 400 });
   }

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -25,8 +25,10 @@ export const POST = async (req: NextRequest) => {
   if (limited) return limited;
 
   // formData() buffers the whole body, so refuse an oversized one before that.
+  // Written as a positive test: a body that declares no length at all cannot be
+  // checked, and chunking past this was the way around the old comparison.
   const declaredLength = Number(req.headers.get("content-length"));
-  if (declaredLength > MAX_UPLOAD_BYTES) return tooLarge();
+  if (!(declaredLength <= MAX_UPLOAD_BYTES)) return tooLarge();
 
   const form = await req.formData();
   const file = form.get("file");

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -2,17 +2,31 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { NextResponse, type NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/auth/session";
+import { rateLimit } from "@/lib/rate-limit";
 import {
   isAllowedImageType,
   MAX_UPLOAD_BYTES,
+  sniffImageType,
   UPLOAD_ROOT,
   uploadNameFor,
 } from "@/lib/uploads";
+
+const tooLarge = () =>
+  NextResponse.json(
+    { error: "That image is larger than 5MB." },
+    { status: 413 },
+  );
 
 export const POST = async (req: NextRequest) => {
   if (!(await requireAdmin(req))) {
     return NextResponse.json({ error: "Not authorized" }, { status: 401 });
   }
+  const limited = rateLimit(req, "upload", 60, 60 * 60 * 1000);
+  if (limited) return limited;
+
+  // formData() buffers the whole body, so refuse an oversized one before that.
+  const declaredLength = Number(req.headers.get("content-length"));
+  if (declaredLength > MAX_UPLOAD_BYTES) return tooLarge();
 
   const form = await req.formData();
   const file = form.get("file");
@@ -25,17 +39,20 @@ export const POST = async (req: NextRequest) => {
       { status: 415 },
     );
   }
-  if (file.size > MAX_UPLOAD_BYTES) {
+  if (file.size > MAX_UPLOAD_BYTES) return tooLarge();
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  if (sniffImageType(bytes) !== file.type) {
     return NextResponse.json(
-      { error: "That image is larger than 5MB." },
-      { status: 413 },
+      { error: "That file is not the image type it claims to be." },
+      { status: 415 },
     );
   }
 
   const name = uploadNameFor(file.type);
   const target = join(UPLOAD_ROOT, name);
   await mkdir(dirname(target), { recursive: true });
-  await writeFile(target, Buffer.from(await file.arrayBuffer()));
+  await writeFile(target, bytes);
 
   return NextResponse.json({ url: `/uploads/${name}` }, { status: 201 });
 };

--- a/app/uploads/[...path]/route.ts
+++ b/app/uploads/[...path]/route.ts
@@ -26,6 +26,8 @@ export const GET = async (
       headers: {
         "content-type": contentTypeForPath(resolved),
         "content-length": String(info.size),
+        // These bytes are user-supplied; never let a browser re-guess the type.
+        "x-content-type-options": "nosniff",
         // Names are random, so a file never changes under the same URL.
         "cache-control": "public, max-age=31536000, immutable",
       },

--- a/lib/auth/keycloak-admin.ts
+++ b/lib/auth/keycloak-admin.ts
@@ -59,6 +59,10 @@ const adminToken = async (): Promise<string> => {
   return access_token;
 };
 
+/** Ids reach these paths from tokens and the database; never let one add a segment. */
+const userPath = (userId: string, suffix = "") =>
+  `/users/${encodeURIComponent(userId)}${suffix}`;
+
 const adminFetch = async (path: string, init: RequestInit = {}) => {
   const { adminBase } = config();
   const token = await adminToken();
@@ -127,7 +131,7 @@ export const effectiveRealmRoles = async (
   userId: string,
 ): Promise<string[]> => {
   const res = await adminFetch(
-    `/users/${userId}/role-mappings/realm/composite`,
+    userPath(userId, "/role-mappings/realm/composite"),
   );
   if (!res.ok) throw new Error(`Keycloak role lookup failed (${res.status}).`);
   const roles = (await res.json()) as { name: string }[];
@@ -150,7 +154,7 @@ export const removeRealmRole = async (userId: string, roleName: string) => {
     throw new Error(`Keycloak realm role "${roleName}" not found.`);
   }
   const role = (await roleRes.json()) as { id: string; name: string };
-  const res = await adminFetch(`/users/${userId}/role-mappings/realm`, {
+  const res = await adminFetch(userPath(userId, "/role-mappings/realm"), {
     method: "DELETE",
     body: JSON.stringify([{ id: role.id, name: role.name }]),
   });
@@ -160,7 +164,7 @@ export const removeRealmRole = async (userId: string, roleName: string) => {
 };
 
 export const setUserEnabled = async (userId: string, enabled: boolean) => {
-  const res = await adminFetch(`/users/${userId}`, {
+  const res = await adminFetch(userPath(userId), {
     method: "PUT",
     body: JSON.stringify({ enabled }),
   });
@@ -168,7 +172,7 @@ export const setUserEnabled = async (userId: string, enabled: boolean) => {
 };
 
 export const deleteUser = async (userId: string) => {
-  const res = await adminFetch(`/users/${userId}`, { method: "DELETE" });
+  const res = await adminFetch(userPath(userId), { method: "DELETE" });
   if (!res.ok && res.status !== 404) {
     throw new Error(`Keycloak user delete failed (${res.status}).`);
   }
@@ -181,7 +185,7 @@ export const assignRealmRole = async (userId: string, roleName: string) => {
   }
   const role = (await roleRes.json()) as { id: string; name: string };
 
-  const res = await adminFetch(`/users/${userId}/role-mappings/realm`, {
+  const res = await adminFetch(userPath(userId, "/role-mappings/realm"), {
     method: "POST",
     body: JSON.stringify([{ id: role.id, name: role.name }]),
   });

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -29,14 +29,20 @@ export const signSession = (identity: KeycloakIdentity): string => {
     name: identity.name,
     roles: identity.roles,
   };
-  return jwt.sign(session, getSessionSecret(), { expiresIn: "1d" });
+  return jwt.sign(session, getSessionSecret(), {
+    algorithm: "HS256",
+    expiresIn: "1d",
+  });
 };
 
 export const getSessionUser = (req: NextRequest): SessionUser | null => {
   const token = req.cookies.get(SESSION_COOKIE)?.value;
   if (!token) return null;
   try {
-    return jwt.verify(token, getSessionSecret()) as SessionUser;
+    // Pinned so the token's own header can never choose the algorithm.
+    return jwt.verify(token, getSessionSecret(), {
+      algorithms: ["HS256"],
+    }) as SessionUser;
   } catch {
     return null;
   }

--- a/lib/db/repository.ts
+++ b/lib/db/repository.ts
@@ -7,9 +7,10 @@ import type { eventsTable, execsTable, signupsTable } from "./schema";
 type JsonbTable = typeof eventsTable | typeof execsTable | typeof signupsTable;
 type Entity<T> = T & { id: string };
 
+/** id last: a stray `id` inside the stored JSON must not shadow the real one. */
 const toEntity = <T>(row: { id: string; data: unknown }): Entity<T> => ({
-  id: row.id,
   ...(row.data as T),
+  id: row.id,
 });
 
 export const toWireRecord = <T>(entity: Entity<T>) => {

--- a/lib/db/repository.ts
+++ b/lib/db/repository.ts
@@ -1,6 +1,7 @@
 import { eq, sql } from "drizzle-orm";
 import { NextResponse, type NextRequest } from "next/server";
 import { requireAdmin } from "@/lib/auth/session";
+import { badJson, jsonObject } from "@/lib/json";
 import { db } from "./index";
 import type { eventsTable, execsTable, signupsTable } from "./schema";
 
@@ -74,7 +75,8 @@ export const createCollectionHandlers = <T>(table: JsonbTable) => ({
     if (!admin) {
       return NextResponse.json({ error: "Not authorized" }, { status: 401 });
     }
-    const input = (await req.json()) as T;
+    const input = await jsonObject<T>(req);
+    if (!input) return badJson();
     const entity = await create<T>(table, input);
     return NextResponse.json(toWireRecord(entity), { status: 201 });
   },
@@ -102,7 +104,8 @@ export const createItemHandlers = <T>(table: JsonbTable) => ({
       return NextResponse.json({ error: "Not authorized" }, { status: 401 });
     }
     const { id } = await params;
-    const patch = (await req.json()) as Partial<T>;
+    const patch = await jsonObject<Partial<T>>(req);
+    if (!patch) return badJson();
     const entity = await update<T>(table, id, patch);
     if (!entity) {
       return NextResponse.json({ error: "Not found" }, { status: 404 });

--- a/lib/execs/patch.ts
+++ b/lib/execs/patch.ts
@@ -1,0 +1,64 @@
+import type { ExecRecord } from "@/lib/api/types";
+import { sanitiseSocials } from "./socials";
+import { isValidTerm } from "./terms";
+
+const MAX_DESCRIPTION = 2000;
+/** Only images this app stored: an arbitrary URL here loads on the team page. */
+const UPLOAD_URL = /^\/uploads\/[A-Za-z0-9/._-]+$/;
+const OBJECT_POSITION = /^\d{1,3}(?:\.\d+)?% \d{1,3}(?:\.\d+)?%$/;
+
+/** The team page calls .trim() on these, so a number here breaks its render. */
+const isText = (value: unknown) =>
+  value === undefined || typeof value === "string";
+
+export const asBool = (value: unknown) =>
+  value === undefined ? undefined : value === true;
+
+/**
+ * Normalises the fields anyone with write access may set, so the admin routes
+ * enforce what the self-service profile route does. Keys the body leaves out
+ * stay out, so a partial patch never clears a field it did not name.
+ */
+export const cleanExec = (
+  body: ExecRecord,
+): { error: string } | { patch: Partial<ExecRecord> } => {
+  if (
+    !isText(body.name) ||
+    !isText(body.title) ||
+    !isText(body.description) ||
+    !isText(body.term) ||
+    !isText(body.image?.url) ||
+    !isText(body.image?.position)
+  ) {
+    return { error: "Expected text." };
+  }
+  if ((body.description?.length ?? 0) > MAX_DESCRIPTION) {
+    return { error: "That bio is too long." };
+  }
+  if (body.term && !isValidTerm(body.term)) {
+    return { error: "Unknown term." };
+  }
+
+  const url = body.image?.url?.trim() ?? "";
+  if (url && !UPLOAD_URL.test(url)) {
+    return { error: "Photos must be uploaded here rather than linked." };
+  }
+  const position = body.image?.position ?? "";
+
+  return {
+    patch: {
+      description: body.description,
+      term: body.term,
+      // sanitiseSocials fills in every platform, so calling it unconditionally
+      // would blank the links a patch never named.
+      socials:
+        body.socials === undefined ? undefined : sanitiseSocials(body.socials),
+      image: body.image && {
+        url,
+        position: OBJECT_POSITION.test(position) ? position : "50% 50%",
+      },
+      // Coerced: this decides what the public API returns.
+      hidden: asBool(body.hidden),
+    },
+  };
+};

--- a/lib/json.ts
+++ b/lib/json.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+/** Null unless the body parsed as an object, so a route can answer 400 rather
+ * than let a syntax error surface as a 500. */
+export const jsonObject = async <T>(req: Request): Promise<T | null> => {
+  const body: unknown = await req.json().catch(() => null);
+  return body && typeof body === "object" ? (body as T) : null;
+};
+
+export const badJson = () =>
+  NextResponse.json({ error: "Expected a JSON object." }, { status: 400 });

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -17,13 +17,15 @@ const clientIp = (req: NextRequest): string => {
   return chain?.at(-1) ?? req.headers.get("x-real-ip") ?? "unknown";
 };
 
+/** Counts per caller IP unless `identity` names something else to count by. */
 export const rateLimit = (
   req: NextRequest,
   bucket: string,
   limit: number,
   windowMs: number,
+  identity?: string,
 ): NextResponse | null => {
-  const key = `${bucket}:${clientIp(req)}`;
+  const key = `${bucket}:${identity ?? clientIp(req)}`;
   const now = Date.now();
   const window = windows.get(key);
 

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -5,6 +5,7 @@ import { NextResponse, type NextRequest } from "next/server";
  * container, so a shared store would be more moving parts than it is worth.
  */
 const windows = new Map<string, { count: number; resetAt: number }>();
+const MAX_WINDOWS = 10_000;
 
 /** Traefik appends the peer it saw, so the last hop is the one a client cannot forge. */
 const clientIp = (req: NextRequest): string => {
@@ -27,9 +28,16 @@ export const rateLimit = (
   const window = windows.get(key);
 
   if (!window || now >= window.resetAt) {
-    if (windows.size > 10_000) {
+    if (windows.size > MAX_WINDOWS) {
       for (const [k, v] of windows) {
         if (now >= v.resetAt) windows.delete(k);
+      }
+      // Sweeping only reclaims expired windows, so a caller spraying addresses
+      // could still grow this without bound. Insertion order is roughly expiry
+      // order, so evicting from the front drops the closest to expiring.
+      for (const k of windows.keys()) {
+        if (windows.size <= MAX_WINDOWS) break;
+        windows.delete(k);
       }
     }
     windows.set(key, { count: 1, resetAt: now + windowMs });

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,52 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Fixed-window limiter kept in process memory. Each environment runs a single
+ * container, so a shared store would be more moving parts than it is worth.
+ */
+const windows = new Map<string, { count: number; resetAt: number }>();
+
+/** Traefik appends the peer it saw, so the last hop is the one a client cannot forge. */
+const clientIp = (req: NextRequest): string => {
+  const chain = req.headers
+    .get("x-forwarded-for")
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return chain?.at(-1) ?? req.headers.get("x-real-ip") ?? "unknown";
+};
+
+export const rateLimit = (
+  req: NextRequest,
+  bucket: string,
+  limit: number,
+  windowMs: number,
+): NextResponse | null => {
+  const key = `${bucket}:${clientIp(req)}`;
+  const now = Date.now();
+  const window = windows.get(key);
+
+  if (!window || now >= window.resetAt) {
+    if (windows.size > 10_000) {
+      for (const [k, v] of windows) {
+        if (now >= v.resetAt) windows.delete(k);
+      }
+    }
+    windows.set(key, { count: 1, resetAt: now + windowMs });
+    return null;
+  }
+
+  window.count += 1;
+  if (window.count > limit) {
+    return NextResponse.json(
+      { error: "Too many requests. Try again shortly." },
+      {
+        status: 429,
+        headers: {
+          "retry-after": String(Math.ceil((window.resetAt - now) / 1000)),
+        },
+      },
+    );
+  }
+  return null;
+};

--- a/lib/uploads.ts
+++ b/lib/uploads.ts
@@ -37,6 +37,37 @@ export const resolveUploadPath = (segments: string[]): string | null => {
   return resolved.startsWith(UPLOAD_ROOT + sep) ? resolved : null;
 };
 
+const ascii = (bytes: Uint8Array, start: number, end: number) =>
+  Buffer.from(bytes.subarray(start, end)).toString("latin1");
+
+const startsWith = (bytes: Uint8Array, signature: number[]) =>
+  signature.every((byte, i) => bytes[i] === byte);
+
+/**
+ * The browser's declared type is just a header, so the extension and the
+ * served content-type would otherwise both derive from something a caller
+ * controls. Reading the actual magic bytes keeps the two honest.
+ */
+export const sniffImageType = (bytes: Uint8Array): string | null => {
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (["GIF87a", "GIF89a"].includes(ascii(bytes, 0, 6))) return "image/gif";
+  if (ascii(bytes, 0, 4) === "RIFF" && ascii(bytes, 8, 12) === "WEBP") {
+    return "image/webp";
+  }
+  // Encoders differ on whether "avif" is the major brand or only a compatible
+  // one, so look across the whole ftyp box rather than at byte 8 alone.
+  if (
+    ascii(bytes, 4, 8) === "ftyp" &&
+    /avif|avis/.test(ascii(bytes, 8, 64))
+  ) {
+    return "image/avif";
+  }
+  return null;
+};
+
 export const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",

--- a/lib/uploads.ts
+++ b/lib/uploads.ts
@@ -59,10 +59,7 @@ export const sniffImageType = (bytes: Uint8Array): string | null => {
   }
   // Encoders differ on whether "avif" is the major brand or only a compatible
   // one, so look across the whole ftyp box rather than at byte 8 alone.
-  if (
-    ascii(bytes, 4, 8) === "ftyp" &&
-    /avif|avis/.test(ascii(bytes, 8, 64))
-  ) {
+  if (ascii(bytes, 4, 8) === "ftyp" && /avif|avis/.test(ascii(bytes, 8, 64))) {
     return "image/avif";
   }
   return null;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,29 @@
 import type { NextConfig } from "next";
 
+/**
+ * `frame-ancestors`/`object-src`/`base-uri` are the parts of a CSP this app can
+ * assert without a nonce pipeline; script-src is deliberately left out rather
+ * than shipped as a permissive rule that only looks like a control.
+ */
+const securityHeaders = [
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Strict-Transport-Security", value: "max-age=63072000" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+  {
+    key: "Content-Security-Policy",
+    value: "frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+  },
+];
+
 const nextConfig: NextConfig = {
   output: "standalone",
   serverExternalPackages: ["pg", "drizzle-orm"],
+  headers: async () => [{ source: "/:path*", headers: securityHeaders }],
 };
 
 export default nextConfig;


### PR DESCRIPTION
## What & why

Fixes from a security review of the app, plus a second pass over that first round.

Authorization:

- Hidden exec tiles are filtered server-side, not just on the team page — a hidden record used to be one `curl` away.
- Session JWT pinned to HS256 on sign and verify.
- Keycloak admin paths encode the user id, so an id cannot add a path segment.
- Row id wins over any `id` inside stored JSON.

Input validation:

- Exec records validated in one shared place, used by the profile route and both admin routes, which previously took anything.
- Photo URLs must point at `/uploads/`, `object-position` must be a percentage pair, bios are capped.
- Text fields must actually be text — the team page calls `.trim()` on them, so a member could otherwise store an object and break `/team` for everyone.
- Partial patches leave out what they do not name, so saving one field no longer clears the photo or the social links.
- Name, email and phone are length-capped at sign-up.
- Malformed JSON answers 400 instead of 500.

Abuse limits (`lib/rate-limit.ts`, new):

- Per-IP limits on login, sign-up, invite-code guesses, page views and uploads.
- Login also limited per username, set above the IP cap so a campus NAT hits the IP one first.
- The limiter's own map is bounded, so spraying addresses cannot grow it without end.

Uploads:

- Magic bytes must match the declared MIME type.
- A body that declares no length is refused; chunking past the size check was the way around it.
- `nosniff` on the file-serving route.

Headers:

- `frame-ancestors`, `object-src`, `base-uri`, HSTS, referrer and permissions policy. `script-src` left out rather than shipped permissive enough to only look like a control.

## How to test

Needs a Keycloak account. No new env vars, no schema changes.

- `curl /api/execs` — hidden tiles absent; log in as a member and they come back.
- `/admin/profile` — save one field at a time, photo and socials survive.
- `curl -X PATCH /api/profile -d '{"description":{"a":1}}'` → 400, not stored.
- `curl -X PATCH /api/profile -d '{"image":{"url":"https://example.com/x.png"}}'` → 400.
- `/admin/execs` as an approver — create and edit still work; social fields want full URLs, as the placeholders show.
- Upload a renamed `.txt` sent as `image/png` → 415.
- 11 bad logins from one IP in 15 minutes → 429 with `retry-after`.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none added
- [x] Schema changes have a generated migration (`npm run db:generate`) — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover`
- [x] No secrets in committed files
