### PR TITLE
Push role changes to the admin UI over SSE

### DIFF
--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -19,6 +19,7 @@ import ExecModal from "./exec-modal";
 import Modal, { ConfirmationModal } from "@/components/ui/modal";
 import { AdminTable, ColumnDef } from "@/components/ui/admin-table";
 import { grantsApproval } from "@/lib/execs/titles";
+import { useSession } from "../session";
 
 type TeamMember = WithKey<ExecRecord>;
 type ExecMatch = {
@@ -60,7 +61,10 @@ export default function ExecutivesManagementPage() {
   const [rejecting, setRejecting] = useState<Signup | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  /** Only approvers can read sign-ups; plain admins just see the tiles. */
+  /** Only approvers can read sign-ups; plain admins just see the tiles. The
+   * flag below re-runs the load when that changes, so gaining the role fills
+   * this in rather than showing an approver column with nothing behind it. */
+  const { user } = useSession();
   const isApprover = signups !== null;
   const accountFor = (exec: TeamMember) =>
     signups?.find((signup) => signup.execKey === exec.$key) ?? null;
@@ -92,7 +96,7 @@ export default function ExecutivesManagementPage() {
         setInvite(null);
       }
     })();
-  }, []);
+  }, [user?.isApprover, user?.isExecutive]);
 
   const review = async (signup: Signup, action: "approve" | "reject") => {
     setError(null);

--- a/app/admin/execs/page.tsx
+++ b/app/admin/execs/page.tsx
@@ -61,9 +61,7 @@ export default function ExecutivesManagementPage() {
   const [rejecting, setRejecting] = useState<Signup | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  /** Only approvers can read sign-ups; plain admins just see the tiles. The
-   * flag below re-runs the load when that changes, so gaining the role fills
-   * this in rather than showing an approver column with nothing behind it. */
+  /** Only approvers can read sign-ups; plain admins just see the tiles. */
   const { user } = useSession();
   const isApprover = signups !== null;
   const accountFor = (exec: TeamMember) =>

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -40,9 +40,7 @@ function AdminShell({ children }: { children: React.ReactNode }) {
     return <LoginForm onSuccess={() => void refresh()} />;
   }
 
-  // Signed in, but Keycloak grants them nothing. Every route behind here would
-  // refuse them, so offer the shell to nobody — but not the login form either,
-  // since their session is fine and signing back in would change nothing.
+  // Signed in, but every route behind here would refuse them.
   if (!user.isMember) {
     return (
       <div className="py-32 text-center">

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { fetchCurrentUser, logout } from "@/lib/api";
-import { useEffect, useState } from "react";
+import { logout } from "@/lib/api";
 import { useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
 import { LoginForm } from "@/components/admin/login-form";
+import { SessionProvider, useSession } from "./session";
 
 const adminTabs = [
   { name: "Dashboard", href: "/admin" },
@@ -13,38 +13,15 @@ const adminTabs = [
   { name: "My Profile", href: "/admin/profile" },
 ];
 
-export default function AdminLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+function AdminShell({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const [loading, setLoading] = useState(true);
-  const [authenticated, setAuthenticated] = useState(false);
-  const [isApprover, setIsApprover] = useState(false);
-  const [isExecutive, setIsExecutive] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    fetchCurrentUser().then((user) => {
-      if (cancelled) return;
-      setAuthenticated(!!user);
-      setIsApprover(!!user?.isApprover);
-      setIsExecutive(!!user?.isExecutive);
-      setLoading(false);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const { user, loading, refresh } = useSession();
 
   const handleLogout = async () => {
     try {
       await logout();
-      setAuthenticated(false);
+      await refresh();
       router.push("/");
     } catch (error) {
       console.error("Logout failed:", error);
@@ -59,8 +36,29 @@ export default function AdminLayout({
     );
   }
 
-  if (!authenticated) {
-    return <LoginForm onSuccess={() => setAuthenticated(true)} />;
+  if (!user) {
+    return <LoginForm onSuccess={() => void refresh()} />;
+  }
+
+  // Signed in, but Keycloak grants them nothing. Every route behind here would
+  // refuse them, so offer the shell to nobody — but not the login form either,
+  // since their session is fine and signing back in would change nothing.
+  if (!user.isMember) {
+    return (
+      <div className="py-32 text-center">
+        <p className="text-lg font-bold">Your access has been removed.</p>
+        <p className="mt-2 text-sm text-neutral-600">
+          Ask a co-president if you think this is a mistake. This page updates
+          on its own if your roles come back.
+        </p>
+        <button
+          onClick={handleLogout}
+          className="mt-6 font-bold text-gray-500 underline hover:text-black"
+        >
+          Log out
+        </button>
+      </div>
+    );
   }
 
   return (
@@ -69,8 +67,8 @@ export default function AdminLayout({
         <div className="flex items-center justify-between mb-8">
           <nav className="flex gap-2">
             {adminTabs
-              .filter((tab) => !tab.approverOnly || isApprover)
-              .filter((tab) => !tab.executiveOnly || isExecutive)
+              .filter((tab) => !tab.approverOnly || user.isApprover)
+              .filter((tab) => !tab.executiveOnly || user.isExecutive)
               .map((tab) => {
                 const isActive =
                   tab.href === "/admin"
@@ -103,5 +101,17 @@ export default function AdminLayout({
         <div className="p-8">{children}</div>
       </div>
     </div>
+  );
+}
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <SessionProvider>
+      <AdminShell>{children}</AdminShell>
+    </SessionProvider>
   );
 }

--- a/app/admin/profile/page.tsx
+++ b/app/admin/profile/page.tsx
@@ -74,7 +74,6 @@ export default function ProfilePage() {
   const [saved, setSaved] = useState<Form>(formFor(null));
   const [steppingDown, setSteppingDown] = useState(false);
   const [stepDownNote, setStepDownNote] = useState<string | null>(null);
-  // Polled, so losing the role elsewhere hides this section on its own.
   const { user, refresh } = useSession();
   const isApprover = !!user?.isApprover;
 

--- a/app/admin/profile/page.tsx
+++ b/app/admin/profile/page.tsx
@@ -6,7 +6,6 @@ import { ImageFocus } from "@/components/ui/image-focus";
 import {
   ExecRecord,
   WithKey,
-  fetchCurrentUser,
   fetchProfile,
   stepDownAsCoPresident,
   updateProfile,
@@ -20,6 +19,7 @@ import {
   type SocialKey,
 } from "@/lib/execs/socials";
 import { academicTerms } from "@/lib/execs/terms";
+import { useSession } from "../session";
 import { useEffect, useMemo, useState } from "react";
 
 type TeamMember = WithKey<ExecRecord>;
@@ -72,19 +72,17 @@ export default function ProfilePage() {
   const [error, setError] = useState<string | null>(null);
   const [form, setForm] = useState<Form>(formFor(null));
   const [saved, setSaved] = useState<Form>(formFor(null));
-  const [isApprover, setIsApprover] = useState(false);
   const [steppingDown, setSteppingDown] = useState(false);
   const [stepDownNote, setStepDownNote] = useState<string | null>(null);
+  // Polled, so losing the role elsewhere hides this section on its own.
+  const { user, refresh } = useSession();
+  const isApprover = !!user?.isApprover;
 
   useEffect(() => {
     void (async () => {
       try {
-        const [exec, me] = await Promise.all([
-          fetchProfile(),
-          fetchCurrentUser().catch(() => null),
-        ]);
+        const exec = await fetchProfile();
         setProfile(exec);
-        setIsApprover(!!me?.isApprover);
         setForm(formFor(exec));
         setSaved(formFor(exec));
       } catch {
@@ -334,7 +332,7 @@ export default function ProfilePage() {
                     try {
                       await stepDownAsCoPresident();
                       setStepDownNote("You are no longer a co-president.");
-                      setIsApprover(false);
+                      await refresh();
                     } catch (err) {
                       setStepDownNote(
                         err instanceof Error

--- a/app/admin/session.tsx
+++ b/app/admin/session.tsx
@@ -9,9 +9,9 @@ import {
   useState,
 } from "react";
 
-/** Matches the server's own role cache, so a poll never reads something the
- * gated routes would still refuse. */
-const POLL_MS = 15_000;
+/** The stream is what makes this feel instant; this is only the net under it,
+ * for a proxy that drops SSE or a watcher that cannot reach Keycloak. */
+const FALLBACK_POLL_MS = 5 * 60_000;
 
 type Session = {
   user: SessionUser | null;
@@ -69,13 +69,20 @@ export const SessionProvider = ({
     const onVisible = () => {
       if (document.visibilityState === "visible") void refresh();
     };
-    const timer = setInterval(onVisible, POLL_MS);
+    const timer = setInterval(onVisible, FALLBACK_POLL_MS);
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", onVisible);
+
+    // Server-sent events carry no payload — they only say "ask again" — so a
+    // stale or spoofed message can never widen what this browser thinks it may
+    // do. EventSource reconnects on its own if the stream drops.
+    const stream = new EventSource("/api/auth/roles-stream");
+    stream.addEventListener("roles", () => void refresh());
 
     return () => {
       cancelled = true;
       clearInterval(timer);
+      stream.close();
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", onVisible);
     };

--- a/app/admin/session.tsx
+++ b/app/admin/session.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { fetchCurrentUser, type SessionUser } from "@/lib/api";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+/** Matches the server's own role cache, so a poll never reads something the
+ * gated routes would still refuse. */
+const POLL_MS = 15_000;
+
+type Session = {
+  user: SessionUser | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+};
+
+const SessionContext = createContext<Session>({
+  user: null,
+  loading: true,
+  refresh: async () => {},
+});
+
+export const useSession = () => useContext(SessionContext);
+
+/**
+ * One poll of /api/auth/me for the whole admin area. Roles are re-read on a
+ * timer and whenever the tab comes back, so a grant or revocation in Keycloak
+ * reaches the tabs without a reload. That request also refreshes the server's
+ * role cache, which keeps what the UI offers and what the API allows in step.
+ */
+export const SessionProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [user, setUser] = useState<SessionUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // fetchCurrentUser answers null for 401 and throws for anything else. Only
+  // the former is a sign-out; polling every 15s makes a blip likely enough
+  // that treating one as a sign-out would eventually log someone out for it.
+  const refresh = useCallback(async () => {
+    try {
+      setUser(await fetchCurrentUser());
+    } catch {
+      // Keep whatever we last knew.
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchCurrentUser()
+      .then((next) => {
+        if (!cancelled) setUser(next);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    // A background tab polling Keycloak every 15s is all cost and no benefit.
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void refresh();
+    };
+    const timer = setInterval(onVisible, POLL_MS);
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [refresh]);
+
+  return (
+    <SessionContext.Provider value={{ user, loading, refresh }}>
+      {children}
+    </SessionContext.Provider>
+  );
+};

--- a/app/admin/session.tsx
+++ b/app/admin/session.tsx
@@ -9,8 +9,7 @@ import {
   useState,
 } from "react";
 
-/** The stream is what makes this feel instant; this is only the net under it,
- * for a proxy that drops SSE or a watcher that cannot reach Keycloak. */
+/** Only a net under the stream, for a proxy that drops SSE. */
 const FALLBACK_POLL_MS = 5 * 60_000;
 
 type Session = {
@@ -27,12 +26,7 @@ const SessionContext = createContext<Session>({
 
 export const useSession = () => useContext(SessionContext);
 
-/**
- * One poll of /api/auth/me for the whole admin area. Roles are re-read on a
- * timer and whenever the tab comes back, so a grant or revocation in Keycloak
- * reaches the tabs without a reload. That request also refreshes the server's
- * role cache, which keeps what the UI offers and what the API allows in step.
- */
+/** One shared /api/auth/me for the whole admin area, kept current by SSE. */
 export const SessionProvider = ({
   children,
 }: {
@@ -41,9 +35,7 @@ export const SessionProvider = ({
   const [user, setUser] = useState<SessionUser | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // fetchCurrentUser answers null for 401 and throws for anything else. Only
-  // the former is a sign-out; polling every 15s makes a blip likely enough
-  // that treating one as a sign-out would eventually log someone out for it.
+  // Null means 401; a throw is a blip and must not read as a sign-out.
   const refresh = useCallback(async () => {
     try {
       setUser(await fetchCurrentUser());
@@ -65,7 +57,6 @@ export const SessionProvider = ({
         if (!cancelled) setLoading(false);
       });
 
-    // A background tab polling Keycloak every 15s is all cost and no benefit.
     const onVisible = () => {
       if (document.visibilityState === "visible") void refresh();
     };
@@ -73,9 +64,7 @@ export const SessionProvider = ({
     document.addEventListener("visibilitychange", onVisible);
     window.addEventListener("focus", onVisible);
 
-    // Server-sent events carry no payload — they only say "ask again" — so a
-    // stale or spoofed message can never widen what this browser thinks it may
-    // do. EventSource reconnects on its own if the stream drops.
+    // Payload-free by design: the client re-reads /api/auth/me to decide.
     const stream = new EventSource("/api/auth/roles-stream");
     stream.addEventListener("roles", () => void refresh());
 

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -7,8 +7,7 @@ import {
   requireMember,
 } from "@/lib/auth/session";
 
-/** The admin UI polls this to keep its tabs honest, so it reads Keycloak fresh
- * rather than trusting the cache it then repopulates for the gated routes. */
+/** Reads Keycloak fresh, repopulating the cache the gated routes share. */
 export const GET = async (req: NextRequest) => {
   const user = getSessionUser(req);
   if (!user) {

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,22 +1,32 @@
 import { NextResponse, type NextRequest } from "next/server";
 import {
   getSessionUser,
+  invalidateRoles,
   requireAdmin,
   requireApprover,
+  requireMember,
 } from "@/lib/auth/session";
 
+/** The admin UI polls this to keep its tabs honest, so it reads Keycloak fresh
+ * rather than trusting the cache it then repopulates for the gated routes. */
 export const GET = async (req: NextRequest) => {
   const user = getSessionUser(req);
   if (!user) {
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
   }
-  const [isExecutive, isApprover] = await Promise.all([
+  invalidateRoles(user.sub);
+
+  const [isExecutive, isApprover, member] = await Promise.all([
     requireAdmin(req),
     requireApprover(req),
+    requireMember(req),
   ]);
   return NextResponse.json({
     ...user,
+    // Live, unlike the roles baked into the session cookie at login.
+    roles: member?.roles ?? [],
     isExecutive: !!isExecutive,
     isApprover: !!isApprover,
+    isMember: !!member,
   });
 };

--- a/app/api/auth/roles-stream/route.ts
+++ b/app/api/auth/roles-stream/route.ts
@@ -4,12 +4,9 @@ import { getSessionUser } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 
-/** Traefik's idle timeout is well under a quiet admin session. */
 const HEARTBEAT_MS = 25_000;
 
-/** Tells one signed-in person, and only them, that their roles moved. The
- * payload is deliberately empty: the client re-reads /api/auth/me, so this
- * stream never becomes a second source of truth for what someone may do. */
+/** Signals one signed-in user that their roles moved. Carries no payload. */
 export const GET = (req: NextRequest) => {
   const user = getSessionUser(req);
   if (!user) return new Response("Not authenticated", { status: 401 });
@@ -31,8 +28,7 @@ export const GET = (req: NextRequest) => {
       const unsubscribe = subscribeToRoleChanges(user.sub, () =>
         send("event: roles\ndata: changed\n\n"),
       );
-      // A comment line is the cheapest thing that stops a proxy culling an
-      // idle stream, and EventSource ignores it.
+      // Stops a proxy culling an idle stream; EventSource ignores it.
       const beat = setInterval(() => send(": ping\n\n"), HEARTBEAT_MS);
 
       req.signal.addEventListener("abort", () => {
@@ -42,7 +38,7 @@ export const GET = (req: NextRequest) => {
         try {
           controller.close();
         } catch {
-          // Already closed by the disconnect itself.
+          // Already closed by the disconnect.
         }
       });
     },

--- a/app/api/auth/roles-stream/route.ts
+++ b/app/api/auth/roles-stream/route.ts
@@ -1,0 +1,59 @@
+import { type NextRequest } from "next/server";
+import { subscribeToRoleChanges } from "@/lib/auth/role-events";
+import { getSessionUser } from "@/lib/auth/session";
+
+export const dynamic = "force-dynamic";
+
+/** Traefik's idle timeout is well under a quiet admin session. */
+const HEARTBEAT_MS = 25_000;
+
+/** Tells one signed-in person, and only them, that their roles moved. The
+ * payload is deliberately empty: the client re-reads /api/auth/me, so this
+ * stream never becomes a second source of truth for what someone may do. */
+export const GET = (req: NextRequest) => {
+  const user = getSessionUser(req);
+  if (!user) return new Response("Not authenticated", { status: 401 });
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let open = true;
+      const send = (chunk: string) => {
+        if (!open) return;
+        try {
+          controller.enqueue(encoder.encode(chunk));
+        } catch {
+          open = false;
+        }
+      };
+
+      send(": connected\n\n");
+      const unsubscribe = subscribeToRoleChanges(user.sub, () =>
+        send("event: roles\ndata: changed\n\n"),
+      );
+      // A comment line is the cheapest thing that stops a proxy culling an
+      // idle stream, and EventSource ignores it.
+      const beat = setInterval(() => send(": ping\n\n"), HEARTBEAT_MS);
+
+      req.signal.addEventListener("abort", () => {
+        open = false;
+        clearInterval(beat);
+        unsubscribe();
+        try {
+          controller.close();
+        } catch {
+          // Already closed by the disconnect itself.
+        }
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-store, no-transform",
+      connection: "keep-alive",
+      "x-accel-buffering": "no",
+    },
+  });
+};

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -32,8 +32,7 @@ export const PATCH = async (req: NextRequest) => {
 
   const body = await jsonObject<ExecRecord>(req);
   if (!body) return badJson();
-  // Only the fields cleanExec returns: name, title and isCurrentExec are the
-  // approver's to set, not the exec's own.
+  // cleanExec omits name/title/isCurrentExec: those are the approver's.
   const cleaned = cleanExec(body);
   if ("error" in cleaned) {
     return NextResponse.json({ error: cleaned.error }, { status: 400 });

--- a/app/api/uploads/route.ts
+++ b/app/api/uploads/route.ts
@@ -24,9 +24,7 @@ export const POST = async (req: NextRequest) => {
   const limited = rateLimit(req, "upload", 60, 60 * 60 * 1000);
   if (limited) return limited;
 
-  // formData() buffers the whole body, so refuse an oversized one before that.
-  // Written as a positive test: a body that declares no length at all cannot be
-  // checked, and chunking past this was the way around the old comparison.
+  // formData() buffers the whole body. Positive test so a missing length fails.
   const declaredLength = Number(req.headers.get("content-length"));
   if (!(declaredLength <= MAX_UPLOAD_BYTES)) return tooLarge();
 

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -9,6 +9,9 @@ export type SessionUser = {
   isExecutive?: boolean;
   /** Holds the approver role, so may manage executives. */
   isApprover?: boolean;
+  /** Current exec or alumnus. False once every role is revoked, which is how
+   * the admin UI notices it should drop back to the login form. */
+  isMember?: boolean;
 };
 
 export type ExecSocialLinks = {

--- a/lib/api/types.ts
+++ b/lib/api/types.ts
@@ -9,8 +9,7 @@ export type SessionUser = {
   isExecutive?: boolean;
   /** Holds the approver role, so may manage executives. */
   isApprover?: boolean;
-  /** Current exec or alumnus. False once every role is revoked, which is how
-   * the admin UI notices it should drop back to the login form. */
+  /** Current exec or alumnus. False once every role is revoked. */
   isMember?: boolean;
 };
 

--- a/lib/auth/keycloak-admin.ts
+++ b/lib/auth/keycloak-admin.ts
@@ -139,10 +139,8 @@ export const effectiveRealmRoles = async (
 };
 
 /**
- * Role and account changes Keycloak has recorded since `since`, as the ids of
- * the users they affected. Needs realm-management `view-events` on the service
- * account, and admin events enabled on the realm; without either this throws
- * and callers fall back to asking again later.
+ * Ids of users whose roles changed since `since`. Needs realm-management
+ * `view-events` and admin events enabled on the realm, or this throws.
  */
 export const recentRoleEvents = async (
   since: number,
@@ -158,8 +156,7 @@ export const recentRoleEvents = async (
   }[];
 
   return events.flatMap(({ time, resourcePath }) => {
-    // authDetails.userId is the admin who made the change; the person it was
-    // made to is only in the path, as users/{id}/role-mappings/realm.
+    // authDetails.userId is the admin who acted; the target is in the path.
     const userId = /^users\/([^/]+)/.exec(resourcePath ?? "")?.[1];
     return userId && time && time > since ? [{ userId, time }] : [];
   });

--- a/lib/auth/keycloak-admin.ts
+++ b/lib/auth/keycloak-admin.ts
@@ -138,6 +138,33 @@ export const effectiveRealmRoles = async (
   return roles.map((role) => role.name);
 };
 
+/**
+ * Role and account changes Keycloak has recorded since `since`, as the ids of
+ * the users they affected. Needs realm-management `view-events` on the service
+ * account, and admin events enabled on the realm; without either this throws
+ * and callers fall back to asking again later.
+ */
+export const recentRoleEvents = async (
+  since: number,
+): Promise<{ userId: string; time: number }[]> => {
+  const res = await adminFetch(
+    "/admin-events?max=100&resourceTypes=REALM_ROLE_MAPPING" +
+      "&resourceTypes=CLIENT_ROLE_MAPPING&resourceTypes=USER",
+  );
+  if (!res.ok) throw new Error(`Keycloak admin events failed (${res.status}).`);
+  const events = (await res.json()) as {
+    time?: number;
+    resourcePath?: string;
+  }[];
+
+  return events.flatMap(({ time, resourcePath }) => {
+    // authDetails.userId is the admin who made the change; the person it was
+    // made to is only in the path, as users/{id}/role-mappings/realm.
+    const userId = /^users\/([^/]+)/.exec(resourcePath ?? "")?.[1];
+    return userId && time && time > since ? [{ userId, time }] : [];
+  });
+};
+
 export const usersWithRealmRole = async (
   roleName: string,
 ): Promise<{ id: string; username: string }[]> => {

--- a/lib/auth/role-events.ts
+++ b/lib/auth/role-events.ts
@@ -1,0 +1,63 @@
+import { recentRoleEvents } from "./keycloak-admin";
+import { invalidateRoles } from "./session";
+
+/**
+ * Keycloak will not call us — no webhook extension is installed — so one
+ * watcher reads its admin-event log on behalf of everyone connected. That is a
+ * single request per tick however many admins have the page open, in place of
+ * every browser asking about itself, and it only runs while someone is
+ * listening. Swapping in a webhook later means replacing `poll` and nothing
+ * else: subscribers already work off `publish`.
+ */
+const POLL_MS = 5_000;
+
+type Listener = () => void;
+
+const listeners = new Map<string, Set<Listener>>();
+let timer: ReturnType<typeof setInterval> | null = null;
+/** Keycloak's clock, not ours: the app container's may differ by seconds. */
+let watermark = 0;
+
+const publish = (userId: string) => {
+  invalidateRoles(userId);
+  for (const notify of listeners.get(userId) ?? []) notify();
+};
+
+const poll = async () => {
+  try {
+    const events = await recentRoleEvents(watermark);
+    const newest = Math.max(watermark, ...events.map((event) => event.time));
+
+    // The first tick only learns where "now" is on Keycloak's clock. Without
+    // it a restart would replay every role change in the log as if it were new.
+    if (watermark === 0) {
+      watermark = newest || Date.now();
+      return;
+    }
+    watermark = newest;
+    for (const { userId } of events) publish(userId);
+  } catch {
+    // Reading events is best-effort: the next tick tries again, and the client
+    // keeps its own slow refresh for the case where this never recovers.
+  }
+};
+
+/** Returns the unsubscribe. The watcher starts with the first listener and
+ * stops with the last, so an empty admin area costs nothing. */
+export const subscribeToRoleChanges = (userId: string, listener: Listener) => {
+  const forUser = listeners.get(userId) ?? new Set<Listener>();
+  forUser.add(listener);
+  listeners.set(userId, forUser);
+
+  timer ??= setInterval(() => void poll(), POLL_MS);
+
+  return () => {
+    forUser.delete(listener);
+    if (forUser.size === 0) listeners.delete(userId);
+    if (listeners.size === 0 && timer) {
+      clearInterval(timer);
+      timer = null;
+      watermark = 0;
+    }
+  };
+};

--- a/lib/auth/role-events.ts
+++ b/lib/auth/role-events.ts
@@ -2,12 +2,9 @@ import { recentRoleEvents } from "./keycloak-admin";
 import { invalidateRoles } from "./session";
 
 /**
- * Keycloak will not call us — no webhook extension is installed — so one
- * watcher reads its admin-event log on behalf of everyone connected. That is a
- * single request per tick however many admins have the page open, in place of
- * every browser asking about itself, and it only runs while someone is
- * listening. Swapping in a webhook later means replacing `poll` and nothing
- * else: subscribers already work off `publish`.
+ * No webhook extension is installed, so one watcher reads Keycloak's admin
+ * event log for everyone connected. Replacing `poll` with a webhook leaves
+ * subscribers untouched.
  */
 const POLL_MS = 5_000;
 
@@ -15,7 +12,7 @@ type Listener = () => void;
 
 const listeners = new Map<string, Set<Listener>>();
 let timer: ReturnType<typeof setInterval> | null = null;
-/** Keycloak's clock, not ours: the app container's may differ by seconds. */
+/** Keycloak's clock, not ours. */
 let watermark = 0;
 
 const publish = (userId: string) => {
@@ -28,8 +25,7 @@ const poll = async () => {
     const events = await recentRoleEvents(watermark);
     const newest = Math.max(watermark, ...events.map((event) => event.time));
 
-    // The first tick only learns where "now" is on Keycloak's clock. Without
-    // it a restart would replay every role change in the log as if it were new.
+    // First tick sets the watermark rather than replaying the log.
     if (watermark === 0) {
       watermark = newest || Date.now();
       return;
@@ -37,13 +33,11 @@ const poll = async () => {
     watermark = newest;
     for (const { userId } of events) publish(userId);
   } catch {
-    // Reading events is best-effort: the next tick tries again, and the client
-    // keeps its own slow refresh for the case where this never recovers.
+    // Best-effort: the next tick retries.
   }
 };
 
-/** Returns the unsubscribe. The watcher starts with the first listener and
- * stops with the last, so an empty admin area costs nothing. */
+/** Returns the unsubscribe. The watcher runs only while someone listens. */
 export const subscribeToRoleChanges = (userId: string, listener: Listener) => {
   const forUser = listeners.get(userId) ?? new Set<Listener>();
   forUser.add(listener);

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -54,21 +54,32 @@ export const getSessionUser = (req: NextRequest): SessionUser | null => {
  * The short cache keeps a single page load to one lookup.
  */
 const ROLE_CACHE_MS = 15_000;
-const roleCache = new Map<string, { roles: string[]; readAt: number }>();
+const roleCache = new Map<
+  string,
+  { roles: Promise<string[] | null>; readAt: number }
+>();
 
-const liveRoles = async (sub: string): Promise<string[] | null> => {
+const liveRoles = (sub: string): Promise<string[] | null> => {
   const cached = roleCache.get(sub);
   if (cached && Date.now() - cached.readAt < ROLE_CACHE_MS) {
     return cached.roles;
   }
-  try {
-    const roles = await effectiveRealmRoles(sub);
-    roleCache.set(sub, { roles, readAt: Date.now() });
-    return roles;
-  } catch {
-    // Fail closed: a revoked role must not survive a Keycloak outage.
+  // The promise is cached, not just its result, so the several role checks a
+  // single request makes collapse into one lookup instead of racing.
+  const roles = effectiveRealmRoles(sub).catch(() => {
+    // Fail closed: a revoked role must not survive a Keycloak outage. Drop the
+    // entry so the next request retries rather than holding the failure.
+    roleCache.delete(sub);
     return null;
-  }
+  });
+  roleCache.set(sub, { roles, readAt: Date.now() });
+  return roles;
+};
+
+/** Forces the next check to re-read Keycloak. /api/auth/me calls this, so the
+ * poll that refreshes the admin UI refreshes what the server enforces too. */
+export const invalidateRoles = (sub: string) => {
+  roleCache.delete(sub);
 };
 
 /**

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -64,11 +64,9 @@ const liveRoles = (sub: string): Promise<string[] | null> => {
   if (cached && Date.now() - cached.readAt < ROLE_CACHE_MS) {
     return cached.roles;
   }
-  // The promise is cached, not just its result, so the several role checks a
-  // single request makes collapse into one lookup instead of racing.
+  // Caching the promise collapses one request's role checks into one lookup.
   const roles = effectiveRealmRoles(sub).catch(() => {
-    // Fail closed: a revoked role must not survive a Keycloak outage. Drop the
-    // entry so the next request retries rather than holding the failure.
+    // Fail closed, but drop the entry so the next request retries.
     roleCache.delete(sub);
     return null;
   });
@@ -76,8 +74,7 @@ const liveRoles = (sub: string): Promise<string[] | null> => {
   return roles;
 };
 
-/** Forces the next check to re-read Keycloak. /api/auth/me calls this, so the
- * poll that refreshes the admin UI refreshes what the server enforces too. */
+/** Forces the next check to re-read Keycloak. */
 export const invalidateRoles = (sub: string) => {
   roleCache.delete(sub);
 };

--- a/lib/execs/patch.ts
+++ b/lib/execs/patch.ts
@@ -3,11 +3,11 @@ import { sanitiseSocials } from "./socials";
 import { isValidTerm } from "./terms";
 
 const MAX_DESCRIPTION = 2000;
-/** Only images this app stored: an arbitrary URL here loads on the team page. */
+/** Only images this app stored. */
 const UPLOAD_URL = /^\/uploads\/[A-Za-z0-9/._-]+$/;
 const OBJECT_POSITION = /^\d{1,3}(?:\.\d+)?% \d{1,3}(?:\.\d+)?%$/;
 
-/** The team page calls .trim() on these, so a number here breaks its render. */
+/** Non-strings break .trim() on the team page. */
 const isText = (value: unknown) =>
   value === undefined || typeof value === "string";
 
@@ -15,9 +15,8 @@ export const asBool = (value: unknown) =>
   value === undefined ? undefined : value === true;
 
 /**
- * Normalises the fields anyone with write access may set, so the admin routes
- * enforce what the self-service profile route does. Keys the body leaves out
- * stay out, so a partial patch never clears a field it did not name.
+ * Normalises the fields anyone with write access may set. Omitted keys stay
+ * omitted, so a partial patch never clears a field it did not name.
  */
 export const cleanExec = (
   body: ExecRecord,
@@ -49,15 +48,13 @@ export const cleanExec = (
     patch: {
       description: body.description,
       term: body.term,
-      // sanitiseSocials fills in every platform, so calling it unconditionally
-      // would blank the links a patch never named.
+      // sanitiseSocials fills in every platform, so absent must skip it.
       socials:
         body.socials === undefined ? undefined : sanitiseSocials(body.socials),
       image: body.image && {
         url,
         position: OBJECT_POSITION.test(position) ? position : "50% 50%",
       },
-      // Coerced: this decides what the public API returns.
       hidden: asBool(body.hidden),
     },
   };

--- a/lib/json.ts
+++ b/lib/json.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 
-/** Null unless the body parsed as an object, so a route can answer 400 rather
- * than let a syntax error surface as a 500. */
+/** Null unless the body parsed as an object, so routes can answer 400. */
 export const jsonObject = async <T>(req: Request): Promise<T | null> => {
   const body: unknown = await req.json().catch(() => null);
   return body && typeof body === "object" ? (body as T) : null;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,13 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-/**
- * Fixed-window limiter kept in process memory. Each environment runs a single
- * container, so a shared store would be more moving parts than it is worth.
- */
+/** Fixed-window limiter in process memory; one container per environment. */
 const windows = new Map<string, { count: number; resetAt: number }>();
 const MAX_WINDOWS = 10_000;
 
-/** Traefik appends the peer it saw, so the last hop is the one a client cannot forge. */
+/** Last hop only: earlier entries are client-supplied. */
 const clientIp = (req: NextRequest): string => {
   const chain = req.headers
     .get("x-forwarded-for")
@@ -34,9 +31,7 @@ export const rateLimit = (
       for (const [k, v] of windows) {
         if (now >= v.resetAt) windows.delete(k);
       }
-      // Sweeping only reclaims expired windows, so a caller spraying addresses
-      // could still grow this without bound. Insertion order is roughly expiry
-      // order, so evicting from the front drops the closest to expiring.
+      // Sweeping frees only expired windows; evict oldest-first for the rest.
       for (const k of windows.keys()) {
         if (windows.size <= MAX_WINDOWS) break;
         windows.delete(k);


### PR DESCRIPTION
## What & why

Admins granted a role had to reload before the Events or Executives tabs appeared. Server-side gating was already live; the client was not. Now role changes are pushed to the browser.

Push:

- `/api/auth/roles-stream` is an SSE endpoint tied to the signed-in user. It carries no payload — it only says "ask again" — so a stale or spoofed message can never widen what a browser thinks it may do.
- One server-side watcher reads Keycloak's admin event log on behalf of everyone connected, rather than each browser asking about itself. That is a single request per tick however many admins have the page open, and it only runs while someone is listening.
- Role changes reach the tabs in about 5s, without a reload.
- Swapping in a real Keycloak webhook later means replacing one function; subscribers already work off the same emitter.

Fallbacks, because a stream can drop:

- A refresh whenever the tab regains focus.
- A slow 5-minute poll behind that. EventSource reconnects on its own.
- A failed refresh keeps the last known session — only a real 401 signs you out, so a blip cannot log someone out.

Client:

- One shared session for the whole admin area (`app/admin/session.tsx`), replacing three separate one-shot fetches that never re-ran.
- Losing every role shows an "access removed" panel rather than the shell, whose pages would all refuse them. Not the login form either: their session is fine and signing back in would change nothing.
- Stepping down as co-president refreshes immediately rather than waiting for the stream.

Server:

- `/api/auth/me` reads Keycloak fresh and repopulates the role cache it just cleared, so what the UI offers and what the API allows cannot disagree.
- Role lookups cache the in-flight promise, not just the result, so the three checks `/api/auth/me` makes collapse into one Keycloak call. A failed lookup drops the entry so the next request retries rather than holding the failure.
- `/api/auth/me` also returns `isMember` and the live `roles`, instead of the roles baked into the session cookie at login.

## Keycloak prerequisites

Both applied to the `brockcsc` realm already:

- [x] Admin events enabled (details left off — only `resourcePath` is needed, and representations would bloat Keycloak's DB).
- [x] `view-events` granted to the `brockcsc-provisioner` service account, which now holds `manage-users`, `view-realm`, `view-events`.

Verified against a real event in the log: the query returns it, `resourcePath` parses to the affected user's id rather than the acting admin's, and `time` is present for the watermark.

## How to test

Needs a Keycloak account and someone who can change realm roles. No new env vars, no schema changes.

- Sign in as an executive with the admin area open. Grant `co-president` in Keycloak and leave the tab alone — Executives Management should appear within ~5s, no reload.
- Revoke it the same way: the tab disappears, and `/api/execs` PATCH starts returning 401 in the same window.
- Revoke every role: the admin area drops to "Your access has been removed."
- Grant `co-president` while sitting on Executives Management — pending sign-ups and the account column fill in, rather than the column appearing empty.
- `curl -N` the stream with a session cookie: expect `: connected`, then `: ping` every 25s.
- Kill the stream (stop the container, or block it) and confirm the UI still updates on tab focus.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [ ] New env vars added to `.env.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none added
- [ ] Schema changes have a generated migration (`npm run db:generate`) — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover`
- [x] No secrets in committed files
