### PR TITLE
Harden the mail search tokeniser and pin workflow token scopes

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,6 +11,8 @@ jobs:
   cleanup:
     if: github.event.ref_type == 'branch' && github.event.ref != 'main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/deploy-mail.yml
+++ b/.github/workflows/deploy-mail.yml
@@ -17,6 +17,8 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: mail
       url: https://mail.brockcsc.ca

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -26,6 +28,7 @@ jobs:
   context:
     needs: checks
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       env_name: ${{ steps.ctx.outputs.env_name }}
       url: ${{ steps.ctx.outputs.url }}
@@ -48,6 +51,8 @@ jobs:
   deploy:
     needs: context
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: ${{ needs.context.outputs.env_name }}
       url: ${{ needs.context.outputs.url }}

--- a/lib/mail/jmap-mail.ts
+++ b/lib/mail/jmap-mail.ts
@@ -182,26 +182,37 @@ const STATES = new Map<string, Condition>([
   ["starred", { hasKeyword: "$flagged" }],
 ]);
 
-const FIELDS = new Map<string, (value: string) => Condition | undefined>([
-  ["from", (value) => ({ from: value })],
-  ["to", (value) => ({ to: value })],
-  ["subject", (value) => ({ subject: value })],
-  [
-    "has",
-    (value) =>
-      value.toLowerCase() === "attachment"
-        ? { hasAttachment: true }
-        : undefined,
-  ],
-  ["is", (value) => STATES.get(value.toLowerCase())],
-]);
-
 const inFolder = (value: string, boxes: Mailbox[]) => {
   const wanted = value.toLowerCase();
   const box = boxes.find(
     (item) => item.name.toLowerCase() === wanted || item.role === wanted,
   );
   return box ? { inMailbox: box.id } : undefined;
+};
+
+const operator = (
+  key: string,
+  value: string,
+  boxes: Mailbox[],
+): Condition | undefined => {
+  switch (key) {
+    case "from":
+      return { from: value };
+    case "to":
+      return { to: value };
+    case "subject":
+      return { subject: value };
+    case "in":
+      return inFolder(value, boxes);
+    case "has":
+      return value.toLowerCase() === "attachment"
+        ? { hasAttachment: true }
+        : undefined;
+    case "is":
+      return STATES.get(value.toLowerCase());
+    default:
+      return undefined;
+  }
 };
 
 const searchConditions = (search: string, boxes: Mailbox[]): Condition[] => {
@@ -212,12 +223,7 @@ const searchConditions = (search: string, boxes: Mailbox[]): Condition[] => {
     const value = quoted ?? bare;
     if (!value) continue;
     const key = field?.toLowerCase();
-    const made =
-      key === "in"
-        ? inFolder(value, boxes)
-        : key
-          ? FIELDS.get(key)?.(value)
-          : null;
+    const made = key ? operator(key, value, boxes) : null;
     if (made) conditions.push(made);
     else text.push(field ? `${field}:${value}` : value);
   }

--- a/lib/mail/jmap-mail.ts
+++ b/lib/mail/jmap-mail.ts
@@ -175,20 +175,26 @@ export type MessagePage = {
 
 type Condition = Record<string, unknown>;
 
-const TERM = /(?:(\w+):)?(?:"([^"]*)"|(\S+))/g;
+const TERM = /(?:(\w{1,32}):)?(?:"([^"]{0,1024})"|(\S+))/g;
 
-const FIELDS: Record<string, (value: string) => Condition | undefined> = {
-  from: (value) => ({ from: value }),
-  to: (value) => ({ to: value }),
-  subject: (value) => ({ subject: value }),
-  has: (value) =>
-    value.toLowerCase() === "attachment" ? { hasAttachment: true } : undefined,
-  is: (value) =>
-    ({
-      unread: { notKeyword: "$seen" },
-      starred: { hasKeyword: "$flagged" },
-    })[value.toLowerCase()],
-};
+const STATES = new Map<string, Condition>([
+  ["unread", { notKeyword: "$seen" }],
+  ["starred", { hasKeyword: "$flagged" }],
+]);
+
+const FIELDS = new Map<string, (value: string) => Condition | undefined>([
+  ["from", (value) => ({ from: value })],
+  ["to", (value) => ({ to: value })],
+  ["subject", (value) => ({ subject: value })],
+  [
+    "has",
+    (value) =>
+      value.toLowerCase() === "attachment"
+        ? { hasAttachment: true }
+        : undefined,
+  ],
+  ["is", (value) => STATES.get(value.toLowerCase())],
+]);
 
 const inFolder = (value: string, boxes: Mailbox[]) => {
   const wanted = value.toLowerCase();
@@ -207,7 +213,11 @@ const searchConditions = (search: string, boxes: Mailbox[]): Condition[] => {
     if (!value) continue;
     const key = field?.toLowerCase();
     const made =
-      key === "in" ? inFolder(value, boxes) : key ? FIELDS[key]?.(value) : null;
+      key === "in"
+        ? inFolder(value, boxes)
+        : key
+          ? FIELDS.get(key)?.(value)
+          : null;
     if (made) conditions.push(made);
     else text.push(field ? `${field}:${value}` : value);
   }


### PR DESCRIPTION
Two unrelated hardening fixes that the new org-wide code scanning surfaced.

**Mail search tokeniser.** Operators were dispatched with `FIELDS[key]` where `key` comes from the user's search box, so every `Object.prototype` member answered as an operator. This is not theoretical:

| search | before | after |
| --- | --- | --- |
| `constructor:x` | `["x"]` — a `String` object in the JMAP filter | `[{"text":"constructor:x"}]` |
| `is:constructor` | `[null]` | `[{"text":"is:constructor"}]` |
| `__proto__:x` | **TypeError: FIELDS[key] is not a function** | `[{"text":"__proto__:x"}]` |

`FIELDS` and the `is:` states are now `Map`s. Unknown operators still fall through to free text, and `from:`, `to:`, `subject:`, `in:`, `has:attachment`, `is:unread`, `is:starred`, quoted values such as `in:"Sent Items"`, bare words and empty input all tokenise byte-for-byte as before — diffed across 37 cases against the old code, and the only lines that moved are the three above.

The `TERM` quantifiers are also bounded (`\w{1,32}` for the operator name, `[^"]{0,1024}` inside quotes) so the regex is linear by construction rather than by argument. Measured, the old regex was already linear — 60k characters of adversarial input matched in ~0.1ms — so the ReDoS finding was not exploitable, but bounded is cheaper to be sure about than a proof. The longest real operator is 7 characters, so nothing reachable changes.

**Workflow permissions.** No job in this repo uses `GITHUB_TOKEN` at all — the deploys authenticate to Komodo with its own key pair, and `cleanup` reaches Postgres over SSH. So the three jobs that check the repository out get `contents: read`, and `context`, which only reads `github.ref` and writes step outputs, gets `permissions: {}`.