### PR TITLE
Build the image on Actions, deploy only on the VPS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,5 @@
 name: CI
 
-# The merge gate. Runs on every pull request - including from forks, which
-# never fire the push-triggered deploy - and on what lands on main or a tag.
-#
-# CodeQL is absent on purpose: this repository has code scanning default setup
-# enabled, and code scanning rejects SARIF from an advanced configuration for a
-# language default setup already covers, so a second analysis here could only
-# ever fail. Its "Analyze (javascript-typescript)" check is the required one.
 on:
   pull_request:
   push:
@@ -33,8 +26,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run format:check
 
-  # Advisory, not a merge gate: an advisory landing in a transitive dependency
-  # is not the fault of the pull request that happens to be open.
   dependency-audit:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 
 # The merge gate. Runs on every pull request - including from forks, which
 # never fire the push-triggered deploy - and on what lands on main or a tag.
+#
+# CodeQL is absent on purpose: this repository has code scanning default setup
+# enabled, and code scanning rejects SARIF from an advanced configuration for a
+# language default setup already covers, so a second analysis here could only
+# ever fail. Its "Analyze (javascript-typescript)" check is the required one.
 on:
   pull_request:
   push:
@@ -13,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
+  lint-and-types:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,23 +33,9 @@ jobs:
       - run: npm run typecheck
       - run: npm run format:check
 
-  codeql:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@v5
-      - uses: github/codeql-action/init@v4
-        with:
-          languages: javascript-typescript
-          build-mode: none
-          queries: security-extended
-      - uses: github/codeql-action/analyze@v4
-
   # Advisory, not a merge gate: an advisory landing in a transitive dependency
   # is not the fault of the pull request that happens to be open.
-  audit:
+  dependency-audit:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+# The merge gate. Runs on every pull request - including from forks, which
+# never fire the push-triggered deploy - and on what lands on main or a tag.
+on:
+  pull_request:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run format:check
+
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v4
+
+  # Advisory, not a merge gate: an advisory landing in a transitive dependency
+  # is not the fault of the pull request that happens to be open.
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+      - run: npm audit --omit=dev --audit-level=high
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: high

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -44,6 +44,5 @@ jobs:
           install -m 600 -D /dev/null ~/.ssh/id_deploy
           echo "$SSH_KEY" > ~/.ssh/id_deploy
           ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
-          ssh -i ~/.ssh/id_deploy "$DEPLOY_USER@$DEPLOY_HOST" \
-            "docker exec postgres psql -U brockcsc -d brockcsc -c \"DROP SCHEMA IF EXISTS $DB_SCHEMA CASCADE;\"" \
+          ssh -i ~/.ssh/id_deploy "$DEPLOY_USER@$DEPLOY_HOST" "drop-db $DB_SCHEMA" \
             || echo "::warning::Schema drop failed - continuing, the daily sweep will catch it"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ env:
   IMAGE: ghcr.io/brockcsc/brockcsc-ca
 
 jobs:
-  build:
+  build-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,8 +40,8 @@ jobs:
 
   # Deliberately not a gate on deploy: a new base-image CVE should shout, not
   # stop a hotfix. It lands in the Security tab either way.
-  scan:
-    needs: build
+  scan-image:
+    needs: build-image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -72,8 +72,9 @@ jobs:
           ignore-unfixed: true
           severity: CRITICAL
           exit-code: "1"
+          trivyignores: .trivyignore
 
-  context:
+  resolve-target:
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
@@ -100,14 +101,14 @@ jobs:
             echo "url=https://$SLUG.$VPS_HOST" >> "$GITHUB_OUTPUT"
           fi
 
-  deploy:
-    needs: [build, context]
+  deploy-stack:
+    needs: [build-image, resolve-target]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     environment:
-      name: ${{ needs.context.outputs.env_name }}
-      url: ${{ needs.context.outputs.url }}
+      name: ${{ needs.resolve-target.outputs.env_name }}
+      url: ${{ needs.resolve-target.outputs.url }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ env:
 
 jobs:
   build-image:
-    runs-on: ubuntu-latest
+    # The VPS is an Oracle Ampere box, so the image has to be arm64. GitHub's
+    # arm runners are free on a public repo, which beats emulating it.
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -31,7 +33,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/arm64
           push: true
           tags: ${{ env.IMAGE }}:${{ github.sha }}
           cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,6 @@ env:
 
 jobs:
   build-image:
-    # The VPS is an Oracle Ampere box, so the image has to be arm64. GitHub's
-    # arm runners are free on a public repo, which beats emulating it.
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -28,8 +26,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # Cache in the registry, not the Actions cache: that one is scoped per
-      # branch, so every preview would start from cold.
       - uses: docker/build-push-action@v6
         with:
           context: .
@@ -40,8 +36,6 @@ jobs:
           cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
           provenance: false
 
-  # Deliberately not a gate on deploy: a new base-image CVE should shout, not
-  # stop a hotfix. It lands in the Security tab either way.
   scan-image:
     needs: build-image
     runs-on: ubuntu-latest
@@ -174,8 +168,6 @@ jobs:
         run: |
           source .github/scripts/komodo.sh
 
-          # The repo is still cloned on the VPS, but only for the compose file -
-          # the image itself already exists, built and pushed by the build job.
           config=$(jq -n --arg branch "$BRANCH" --arg environment "$ENVIRONMENT" '{
             server: "wayfarerbx-vps",
             repo: "BrockCSC/website",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,24 +9,71 @@ concurrency:
   group: deploy-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  IMAGE: ghcr.io/brockcsc/brockcsc-ca
+
 jobs:
-  checks:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run typecheck
-      - run: npm run format:check
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Cache in the registry, not the Actions cache: that one is scoped per
+      # branch, so every preview would start from cold.
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
+          provenance: false
+
+  # Deliberately not a gate on deploy: a new base-image CVE should shout, not
+  # stop a hotfix. It lands in the Security tab either way.
+  scan:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ github.sha }}
+          format: sarif
+          output: trivy.sarif
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+      - uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy.sarif
+          category: trivy-image
+      - uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ github.sha }}
+          format: table
+          ignore-unfixed: true
+          severity: CRITICAL
+          exit-code: "1"
 
   context:
-    needs: checks
     runs-on: ubuntu-latest
     permissions: {}
     outputs:
@@ -54,7 +101,7 @@ jobs:
           fi
 
   deploy:
-    needs: context
+    needs: [build, context]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,9 +110,6 @@ jobs:
       url: ${{ needs.context.outputs.url }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
 
       - name: Sync GitHub secrets to Komodo Variables
         env:
@@ -114,23 +158,43 @@ jobs:
         env:
           REF: ${{ github.ref }}
           VPS_HOST: ${{ vars.VPS_HOST }}
+          IMAGE: ${{ env.IMAGE }}:${{ github.sha }}
 
-      - uses: BrockCSC/komodo-deploy/deploy@v1
-        with:
-          komodo-host: ${{ vars.KOMODO_HOST }}
-          komodo-api-key: ${{ secrets.KOMODO_API_KEY }}
-          komodo-api-secret: ${{ secrets.KOMODO_API_SECRET }}
-          build-name: brockcsc
-          server: wayfarerbx-vps
-          repo: BrockCSC/website
-          build-path: .
-          dockerfile-path: Dockerfile
-          image-name: brockcsc-ca
-          branch: ${{ steps.deploy-context.outputs.branch }}
-          stack-name: ${{ steps.deploy-context.outputs.stack-name }}
-          compose-file-paths: deploy/docker-compose.yml
-          environment: ${{ steps.deploy-context.outputs.environment }}
-          commit-sha: ${{ github.sha }}
+      - name: Ensure and deploy the stack
+        env:
+          KOMODO_HOST: ${{ vars.KOMODO_HOST }}
+          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
+          KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+          STACK_NAME: ${{ steps.deploy-context.outputs.stack-name }}
+          BRANCH: ${{ steps.deploy-context.outputs.branch }}
+          ENVIRONMENT: ${{ steps.deploy-context.outputs.environment }}
+        run: |
+          source .github/scripts/komodo.sh
+
+          # The repo is still cloned on the VPS, but only for the compose file -
+          # the image itself already exists, built and pushed by the build job.
+          config=$(jq -n --arg branch "$BRANCH" --arg environment "$ENVIRONMENT" '{
+            server: "wayfarerbx-vps",
+            repo: "BrockCSC/website",
+            branch: $branch,
+            git_provider: "github.com",
+            file_paths: ["deploy/docker-compose.yml"],
+            auto_pull: true,
+            destroy_before_deploy: false,
+            webhook_enabled: false,
+            environment: $environment
+          }')
+
+          if komodo /read "$(jq -n --arg s "$STACK_NAME" '{type:"GetStack", params:{stack:$s}}')" quiet >/dev/null; then
+            komodo /write "$(jq -n --arg id "$STACK_NAME" --argjson config "$config" \
+              '{type:"UpdateStack", params:{id:$id, config:$config}}')" >/dev/null
+          else
+            komodo /write "$(jq -n --arg name "$STACK_NAME" --argjson config "$config" \
+              '{type:"CreateStack", params:{name:$name, config:$config}}')" >/dev/null
+          fi
+
+          update=$(komodo /execute "$(jq -n --arg s "$STACK_NAME" '{type:"DeployStack", params:{stack:$s}}')")
+          komodo_await "$update" 60 >/dev/null
 
       - uses: BrockCSC/komodo-deploy/ensure-action@v1
         with:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,2 @@
-# CVE-2026-59873 - node-tar gzip bomb DoS, in the copy of tar that npm bundles
-# inside the node:22-alpine base image. The runtime never invokes npm; the image
-# starts `node server.js`. Drop this line once the base image ships tar 7.5.19.
+# npm's bundled tar in node:22-alpine; the runtime never invokes npm.
 CVE-2026-59873

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# CVE-2026-59873 - node-tar gzip bomb DoS, in the copy of tar that npm bundles
+# inside the node:22-alpine base image. The runtime never invokes npm; the image
+# starts `node server.js`. Drop this line once the base image ships tar 7.5.19.
+CVE-2026-59873

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,13 +200,22 @@ bounce IMAP.
 Self-hosted, orchestrated by [Komodo](https://komo.do) through the reusable actions in
 [`BrockCSC/komodo-deploy`](https://github.com/BrockCSC/komodo-deploy).
 
-<img src="public/readme/arch-deploy.svg" alt="Deploy pipeline: a push or tag runs lint, typecheck and format checks; deploy-context reads the ref; the job waits on its GitHub Environment before Komodo builds the image and deploys the Stack. A tag lands on production, main on uat, any other branch on its own preview" width="850" />
+**The VPS does not build anything.** GitHub Actions builds the image and pushes it to
+`ghcr.io/brockcsc/brockcsc-ca:<commit-sha>`; the VPS pulls that tag and runs it. Actions minutes are
+free and unlimited on a public repo, VPS cores are not — and a preview deploy no longer competes with
+production for them.
 
-| Workflow                                              | Trigger                                             | What it does                                                                                                   |
-| ----------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `.github/workflows/deploy.yml` — **Build & Deploy**   | push to any branch, tags `v*`                       | lint + typecheck + `format:check`, syncs GitHub secrets into Komodo Variables, then builds and deploys a Stack |
-| `.github/workflows/deploy-mail.yml` — **Deploy Mail** | push to `main` touching `deploy/mail/**`, or manual | deploys the single long-lived `brockcsc-mail` Stack                                                            |
-| `.github/workflows/cleanup.yml` — **Cleanup**         | branch deleted                                      | deletes that branch's Komodo Stack and drops its `preview_*` schema                                            |
+<img src="public/readme/arch-deploy.svg" alt="Deploy pipeline: a push or tag builds the image on GitHub Actions and pushes it to GHCR; deploy-context reads the ref; the job waits on its GitHub Environment before Komodo pulls the image and deploys the Stack. A tag lands on production, main on uat, any other branch on its own preview" width="850" />
+
+| Workflow                                              | Trigger                                             | What it does                                                                                           |
+| ----------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `.github/workflows/ci.yml` — **CI**                   | every pull request, push to `main`, tags `v*`       | lint + typecheck + `format:check`, CodeQL, `npm audit`, dependency review — the merge gate             |
+| `.github/workflows/deploy.yml` — **Build & Deploy**   | push to any branch, tags `v*`                       | builds and pushes the image, scans it with Trivy, syncs secrets into Komodo Variables, deploys a Stack |
+| `.github/workflows/deploy-mail.yml` — **Deploy Mail** | push to `main` touching `deploy/mail/**`, or manual | deploys the single long-lived `brockcsc-mail` Stack                                                    |
+| `.github/workflows/cleanup.yml` — **Cleanup**         | branch deleted                                      | deletes that branch's Komodo Stack and drops its `preview_*` schema                                    |
+
+The image scan does not gate the deploy: a CVE published against the base image overnight should
+shout, not stand between you and a hotfix. Findings land in the repository's Security tab.
 
 `komodo/deploy-context.mjs` reads `GITHUB_REF` and prints the Stack's whole `KEY=VALUE` environment
 block. Secrets are never in it — they are `[[BROCKCSC_NAME]]` placeholders Komodo resolves from its
@@ -248,7 +257,9 @@ Before opening a PR:
 npm run lint && npm run typecheck && npm run format:check && npm run build
 ```
 
-CI runs the first three and fails the deploy job if any of them do.
+CI runs the first three, plus CodeQL and a dependency review, and `main` will not take a pull request
+until they pass. `npm audit` runs too but does not block: an advisory in a transitive dependency is
+not the fault of whichever PR is open when it lands.
 
 ## Opening a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ production for them.
 
 | Workflow                                              | Trigger                                             | What it does                                                                                           |
 | ----------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `.github/workflows/ci.yml` — **CI**                   | every pull request, push to `main`, tags `v*`       | lint + typecheck + `format:check`, CodeQL, `npm audit`, dependency review — the merge gate             |
+| `.github/workflows/ci.yml` — **CI**                   | every pull request, push to `main`, tags `v*`       | lint + typecheck + `format:check`, `npm audit`, dependency review — the merge gate                     |
 | `.github/workflows/deploy.yml` — **Build & Deploy**   | push to any branch, tags `v*`                       | builds and pushes the image, scans it with Trivy, syncs secrets into Komodo Variables, deploys a Stack |
 | `.github/workflows/deploy-mail.yml` — **Deploy Mail** | push to `main` touching `deploy/mail/**`, or manual | deploys the single long-lived `brockcsc-mail` Stack                                                    |
 | `.github/workflows/cleanup.yml` — **Cleanup**         | branch deleted                                      | deletes that branch's Komodo Stack and drops its `preview_*` schema                                    |
@@ -257,8 +257,9 @@ Before opening a PR:
 npm run lint && npm run typecheck && npm run format:check && npm run build
 ```
 
-CI runs the first three, plus CodeQL and a dependency review, and `main` will not take a pull request
-until they pass. `npm audit` runs too but does not block: an advisory in a transitive dependency is
+CI runs the first three plus a dependency review, and `main` will not take a pull request until they
+pass — along with CodeQL, which runs from the repository's code scanning default setup rather than
+from a workflow here. `npm audit` runs too but does not block: an advisory in a transitive dependency is
 not the fault of whichever PR is open when it lands.
 
 ## Opening a pull request

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,6 @@
 # Shared across every environment - differences come entirely from env vars
-# Komodo sets per Stack (image tag, hostname, secrets, DB).
+# Komodo sets per Stack (image, hostname, secrets, DB). The image is built and
+# pushed by GitHub Actions; the VPS only pulls it.
 networks:
   wayfarer-net:
     external: true
@@ -8,8 +9,7 @@ services:
   # Uploads volume ownership comes from the image: the Dockerfile creates
   # /data/uploads as nextjs:nodejs, which an empty volume inherits on first mount.
   app:
-    image: brockcsc-ca:${IMAGE_TAG}
-    pull_policy: never
+    image: ${IMAGE}
     container_name: ${PROJECT_NAME}-app
     restart: unless-stopped
     networks: [wayfarer-net]
@@ -37,6 +37,9 @@ services:
       - STALWART_ADMIN_SECRET=${STALWART_ADMIN_SECRET}
       - OCI_COMPARTMENT_OCID=${OCI_COMPARTMENT_OCID}
       - PROTECTED_MAIL_USERS=${PROTECTED_MAIL_USERS}
+      - MAIL_DAILY_LIMIT=${MAIL_DAILY_LIMIT}
+      - MAIL_SITE_URL=${MAIL_SITE_URL}
+      - ADMIN_MAIL_GROUP=${ADMIN_MAIL_GROUP}
       - ADMIN_SUBDOMAIN=${ADMIN_SUBDOMAIN}
       - PUBLIC_SUBDOMAIN=${PUBLIC_SUBDOMAIN}
     healthcheck:

--- a/komodo/deploy-context.mjs
+++ b/komodo/deploy-context.mjs
@@ -8,6 +8,11 @@ if (!VPS_HOST) {
   throw new Error("VPS_HOST is not set.");
 }
 
+const IMAGE = process.env.IMAGE;
+if (!IMAGE) {
+  throw new Error("IMAGE is not set.");
+}
+
 const slugify = (branch) =>
   branch
     .toLowerCase()
@@ -46,6 +51,7 @@ const databaseUrl = `postgresql://brockcsc:[[BROCKCSC_DB_PASSWORD]]@postgres:543
 const adminSubdomain = `admin.${subdomain}`;
 
 const environment = [
+  `IMAGE=${IMAGE}`,
   `PROJECT_NAME=${projectName}`,
   `SUBDOMAIN=${subdomain}`,
   `ADMIN_SUBDOMAIN=${adminSubdomain}`,
@@ -75,7 +81,7 @@ const environment = [
 ].join("\n");
 
 console.log(
-  `Deploying ${projectName} from ${branch} -> https://${subdomain} (+ https://${adminSubdomain})`,
+  `Deploying ${IMAGE} as ${projectName} from ${branch} -> https://${subdomain} (+ https://${adminSubdomain})`,
 );
 
 const output = process.env.GITHUB_OUTPUT;

--- a/public/readme/arch-deploy.svg
+++ b/public/readme/arch-deploy.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 520" width="880" height="520" role="img" aria-label="Deploy pipeline: a push or tag runs checks, then deploy-context, then a GitHub Environment approval, then Komodo builds and deploys a Stack — tags go to production, main goes to UAT, any other branch gets its own preview">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 880 520" width="880" height="520" role="img" aria-label="Deploy pipeline: a push or tag builds the image on GitHub Actions and pushes it to GHCR, then deploy-context, then a GitHub Environment approval, then Komodo pulls the image and deploys a Stack — tags go to production, main goes to UAT, any other branch gets its own preview">
   <title>Deploy pipeline</title>
 
   <defs>
@@ -41,9 +41,9 @@
 
   <g>
     <rect x="211" y="96" width="132" height="76" rx="14" fill="#ffffff" stroke="#101012" stroke-width="2.5" />
-    <text class="h" x="227" y="124">CHECKS</text>
-    <text class="b" x="227" y="144">lint · typecheck</text>
-    <text class="b" x="227" y="158">format:check</text>
+    <text class="h" x="227" y="124">BUILD</text>
+    <text class="b" x="227" y="144">image built here,</text>
+    <text class="b" x="227" y="158">pushed to GHCR</text>
   </g>
   <path d="M347 134 H370" stroke="#101012" stroke-width="2.5" marker-end="url(#dink)" />
 
@@ -69,7 +69,7 @@
   <g>
     <rect x="700" y="96" width="132" height="76" rx="14" fill="#ffffff" stroke="#101012" stroke-width="2.5" />
     <text class="h" x="716" y="124">KOMODO</text>
-    <text class="b" x="716" y="144">builds the image,</text>
+    <text class="b" x="716" y="144">pulls the image,</text>
     <text class="b" x="716" y="158">deploys the Stack</text>
   </g>
 


### PR DESCRIPTION
## What & why

The VPS was cloning the repo and running `npm ci` + `next build` for **every push on every branch**, competing with production for its own cores. Actions minutes are free and unlimited on a public repo, so the image is built and pushed to GHCR there and the VPS only pulls a tag.

**Build & Deploy** (`deploy.yml`)
- `build-image` — buildx → `ghcr.io/brockcsc/brockcsc-ca:<sha>`, `linux/amd64`, cache in the registry rather than the Actions cache (that one is scoped per branch, so every preview would start cold).
- `scan-image` — Trivy on the pushed image, SARIF into the Security tab. Deliberately **not** a gate on deploy: a base-image CVE published overnight should shout, not stand between a hotfix and production.
- `resolve-target` / `deploy-stack` — `komodo-deploy/deploy` always runs a Komodo Build, so the stack ensure + `DeployStack` are inline here now, in the same shape `deploy-mail.yml` already uses.

**CI** (`ci.yml`, new) — `lint-and-types`, `dependency-review`, and advisory `dependency-audit`. Its own workflow because a fork's pull request never fires the push-triggered deploy, and the merge gate has to cover forks. CodeQL is not here on purpose: this repo has code scanning **default setup** enabled, and code scanning rejects SARIF from an advanced config for a language default setup already covers — the first run of this PR proved it by failing. Its `Analyze (javascript-typescript)` check is required instead.

**Dependabot** (`dependabot.yml`, new) — npm (minor/patch grouped), actions, docker.

**Branch protection** — the `main` ruleset now requires a pull request and green `lint-and-types`, `dependency-review` and `Analyze (javascript-typescript)`, with no bypass.

### Fixes found on the way

- `cleanup.yml` sent `docker exec postgres psql …` over SSH, but `ssh-dispatch.sh` is a forced command accepting only `drop-db <schema>` — the drop was failing into its own warning and leaving preview schemas for the daily sweep.
- `MAIL_DAILY_LIMIT`, `MAIL_SITE_URL` and `ADMIN_MAIL_GROUP` were emitted into the Stack environment but never forwarded by compose, so those overrides stopped there. Invisible because the values matched the code defaults.
- `.trivyignore` carries CVE-2026-59873 (node-tar gzip bomb) — it is in the `tar` that **npm bundles inside `node:22-alpine`**, and production runs `node server.js` and never invokes npm. Ignored by id with a note to drop the line when the base image catches up, rather than by skipping the path, which would hide whatever lands there next.

## How to test

1. This PR's own run is the test: `build-image` pushes `ghcr.io/brockcsc/brockcsc-ca:<sha>`, `deploy-stack` brings up the preview from that tag, and the environment URL appears on the run.
2. Confirm the VPS pulled rather than built — the Komodo Build resource does not run at all now.
3. `scan-image` should be green with the `.trivyignore` in place.

**After merging, three things need a human:**
1. Confirm the new `brockcsc-ca` package under the org is **Public**, or the VPS pull will 401.
2. Delete the now-orphaned Komodo Build resource `brockcsc`.
3. Verify `ssh <deploy-user>@<host> "drop-db preview_test"` works — the forced-command fix is unverified from here.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `.env.local.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — no new vars; three existing ones are now actually forwarded by compose
- [x] Schema changes have a generated migration — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover` — no route changes
- [x] Checked in both light and dark themes — no UI changes
- [x] No secrets, internal hostnames or IPs in committed files