### PR TITLE
Set up club mail in Apple Mail, Gmail, Outlook and friends

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,13 @@ Send limits (`lib/mail/limit.ts`) count the Sent mailbox since local midnight vi
 `POST /api/mail/send` returns **429**. Caps per message: 100 KB text, 400 KB HTML, 20 attachments,
 50 recipients, 15 MB per uploaded file.
 
+**Outside mail apps.** Keycloak passwords do not authenticate against Stalwart, so IMAP and SMTP need
+a Stalwart app password. `/admin/mail/setup` lets a member mint one per device and revoke it, through
+`x:AppPassword/set` in `lib/mail/stalwart.ts`; the secret is returned once and never readable again.
+`makeMailboxReadOnly` revokes every one of them, so a stepped-down exec's mail app stops when their
+portal access does. IMAP is `mail.brockcsc.ca:993` and submission `:465`, both SSL, username being the
+full address — the same values Stalwart publishes at `autoconfig.brockcsc.ca`.
+
 The mail stack (`deploy/mail/docker-compose.yml`) has its own workflow, so website commits never
 bounce IMAP.
 

--- a/app/admin/mail/page.tsx
+++ b/app/admin/mail/page.tsx
@@ -15,6 +15,7 @@ import { Compose, type Draft } from "./compose";
 import { buildQuote } from "./html";
 import { ask } from "../ask";
 import type { Contact } from "./recipient-input";
+import Link from "next/link";
 
 const PAGE = 50;
 
@@ -418,6 +419,12 @@ export default function MailPage() {
           }}
         />
         <Allowance refresh={reload} />
+        <Link
+          className="shrink-0 rounded-[10px] border-2 border-line bg-surface px-3 py-2 text-center text-xs font-bold text-ink hover:bg-tint"
+          href="/admin/mail/setup"
+        >
+          Set up on your phone
+        </Link>
       </aside>
 
       <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden rounded-[20px] border-2 border-line bg-surface shadow-brut">

--- a/app/admin/mail/setup/app-passwords.tsx
+++ b/app/admin/mail/setup/app-passwords.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { field, labelClass } from "../../users/ui";
+
+type AppPassword = {
+  id: string;
+  description: string;
+  createdAt: string;
+};
+
+const created = (value: string) => {
+  const at = new Date(value);
+  return Number.isNaN(at.getTime())
+    ? ""
+    : at.toLocaleDateString("en-CA", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+};
+
+export function AppPasswords() {
+  const [list, setList] = useState<AppPassword[] | null>(null);
+  const [description, setDescription] = useState("");
+  const [secret, setSecret] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = async () => {
+    const res = await fetch("/api/mail/app-passwords");
+    setList(res.ok ? ((await res.json()) as AppPassword[]) : []);
+  };
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        await load();
+      } catch {
+        setList([]);
+      }
+    })();
+  }, []);
+
+  const create = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!description.trim() || busy) return;
+    setBusy(true);
+    setError(null);
+    setSecret(null);
+    try {
+      const res = await fetch("/api/mail/app-passwords", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: description.trim() }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        secret?: string;
+        error?: string;
+      };
+      if (!res.ok || !data.secret) {
+        throw new Error(data.error ?? "Could not create that.");
+      }
+      setSecret(data.secret);
+      setDescription("");
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not create that.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const revoke = async (id: string) => {
+    setBusy(true);
+    await fetch(`/api/mail/app-passwords/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    }).catch(() => null);
+    await load().catch(() => {});
+    setBusy(false);
+  };
+
+  return (
+    <div>
+      <form className="flex flex-wrap items-end gap-3" onSubmit={create}>
+        <div className="min-w-[220px] flex-1">
+          <label className={labelClass} htmlFor="app-password-name">
+            What is it for?
+          </label>
+          <input
+            className={field}
+            id="app-password-name"
+            maxLength={60}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="iPhone Mail"
+            value={description}
+          />
+        </div>
+        <Button disabled={busy || !description.trim()} type="submit">
+          {busy ? "Working..." : "Create"}
+        </Button>
+      </form>
+
+      {error && (
+        <p className="mt-2 text-sm font-semibold text-destructive">{error}</p>
+      )}
+
+      {secret && (
+        <div className="mt-4 rounded-[14px] border-2 border-brand bg-tint p-4">
+          <p className="text-sm font-bold text-ink">
+            Copy this now. It is not shown again.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-3">
+            <code className="min-w-0 flex-1 break-all rounded-[10px] border-2 border-line bg-surface px-3 py-2 font-mono text-sm text-ink">
+              {secret}
+            </code>
+            <Button
+              onClick={() => {
+                void navigator.clipboard
+                  ?.writeText(secret)
+                  .then(() => setCopied(true))
+                  .catch(() => {});
+              }}
+              size="sm"
+              type="button"
+              variant="secondary"
+            >
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+          <p className="mt-2 text-xs text-subtle">
+            Paste it into your mail app as the password. If you lose it, revoke
+            it here and make another.
+          </p>
+        </div>
+      )}
+
+      <div className="mt-5">
+        {list === null ? (
+          <p className="text-sm text-subtle">Loading...</p>
+        ) : list.length === 0 ? (
+          <p className="text-sm text-subtle">
+            You have not made one yet. Create one per device, so losing a phone
+            costs you only that phone.
+          </p>
+        ) : (
+          <ul className="divide-y-2 divide-line border-t-2 border-line">
+            {list.map((one) => (
+              <li
+                key={one.id}
+                className="flex flex-wrap items-center justify-between gap-3 py-2.5"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-bold text-ink">
+                    {one.description}
+                  </span>
+                  {created(one.createdAt) && (
+                    <span className="block text-xs text-subtle">
+                      Added {created(one.createdAt)}
+                    </span>
+                  )}
+                </span>
+                <Button
+                  disabled={busy}
+                  onClick={() => void revoke(one.id)}
+                  size="xs"
+                  type="button"
+                  variant="destructive"
+                >
+                  Revoke
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/mail/setup/clients.ts
+++ b/app/admin/mail/setup/clients.ts
@@ -1,0 +1,73 @@
+export type ClientGuide = {
+  name: string;
+  note?: string;
+  steps: string[];
+};
+
+export const MAIL_HOST = "mail.brockcsc.ca";
+
+export const SERVER_SETTINGS = [
+  { label: "Incoming (IMAP)", value: `${MAIL_HOST}, port 993, SSL/TLS` },
+  { label: "Outgoing (SMTP)", value: `${MAIL_HOST}, port 465, SSL/TLS` },
+  { label: "Username", value: "your full club address" },
+  {
+    label: "Password",
+    value: "an app password from above, not your usual one",
+  },
+];
+
+export const CLIENT_GUIDES: ClientGuide[] = [
+  {
+    name: "iPhone and iPad",
+    note: "Mail fills the servers in for you once it recognises the domain.",
+    steps: [
+      "Settings › Apps › Mail › Mail Accounts › Add Account › Other.",
+      "Add Mail Account, then enter your name, your club address and the app password.",
+      "Tap Next. If it asks for servers, choose IMAP and use the settings below for both incoming and outgoing.",
+      "Tap Save.",
+    ],
+  },
+  {
+    name: "Mac (Apple Mail)",
+    steps: [
+      "Mail › Settings › Accounts › + › Other Mail Account.",
+      "Enter your name, your club address and the app password, then Sign In.",
+      "If it cannot find the settings, enter the ones below and pick IMAP.",
+    ],
+  },
+  {
+    name: "Gmail app (Android and iPhone)",
+    note: "The Gmail app can carry other mailboxes, but it will not fetch these settings for you.",
+    steps: [
+      "Open the Gmail app, tap your avatar › Add another account › Other.",
+      "Enter your club address, tap Next, then choose Personal (IMAP).",
+      "Enter the app password.",
+      "Set the incoming server to the IMAP settings below, then the outgoing server to the SMTP ones.",
+    ],
+  },
+  {
+    name: "Outlook (desktop and mobile)",
+    note: "Outlook usually finds the settings on its own through autodiscover.",
+    steps: [
+      "Add an account and enter your club address.",
+      "When it asks for a provider, choose IMAP.",
+      "Enter the app password. If Outlook asks for servers, use the settings below.",
+    ],
+  },
+  {
+    name: "Thunderbird",
+    note: "Thunderbird reads our autoconfig, so the servers should appear by themselves.",
+    steps: [
+      "Account Settings › Account Actions › Add Mail Account.",
+      "Enter your name, your club address and the app password.",
+      "Press Configure manually only if the automatic settings do not appear.",
+    ],
+  },
+  {
+    name: "Anything else",
+    steps: [
+      "Any app that speaks IMAP works: use the settings below.",
+      "If it offers POP instead of IMAP, prefer IMAP - POP pulls mail off the server and other devices then miss it.",
+    ],
+  },
+];

--- a/app/admin/mail/setup/page.tsx
+++ b/app/admin/mail/setup/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Panel } from "../../users/ui";
+import { AppPasswords } from "./app-passwords";
+import { CLIENT_GUIDES, SERVER_SETTINGS } from "./clients";
+
+export default function MailSetupPage() {
+  const [address, setAddress] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/mail/me")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { email: string | null } | null) =>
+        setAddress(data?.email ?? null),
+      )
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="mx-auto w-full max-w-[860px] px-5 py-10">
+      <Link
+        className="text-sm font-bold text-brand underline underline-offset-4"
+        href="/admin/mail"
+      >
+        Back to mail
+      </Link>
+      <h1 className="mt-3 text-3xl font-extrabold text-ink">
+        Your club mail on your own apps
+      </h1>
+      <p className="mt-2 max-w-prose text-subtle">
+        {address ? (
+          <>
+            Read and send from <strong className="text-ink">{address}</strong>{" "}
+            in Apple Mail, the Gmail app, Outlook or anything else that speaks
+            IMAP.
+          </>
+        ) : (
+          <>
+            Read and send from your club address in Apple Mail, the Gmail app,
+            Outlook or anything else that speaks IMAP.
+          </>
+        )}
+      </p>
+
+      <div className="mt-8 flex flex-col gap-6">
+        <Panel
+          note="Your Brock sign-in will not work in a mail app. Make an app password instead, one per device, and revoke it if that device goes missing."
+          title="1. Create an app password"
+        >
+          <AppPasswords />
+        </Panel>
+
+        <Panel
+          note="Most apps fill these in once you enter your address. Reach for them if yours asks."
+          title="2. Server settings"
+        >
+          <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-[auto_1fr]">
+            {SERVER_SETTINGS.map((setting) => (
+              <div className="contents" key={setting.label}>
+                <dt className="text-sm font-semibold text-subtle">
+                  {setting.label}
+                </dt>
+                <dd className="text-sm font-bold text-ink">{setting.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </Panel>
+
+        <Panel title="3. Add it to your app">
+          <div className="flex flex-col gap-4">
+            {CLIENT_GUIDES.map((guide) => (
+              <details
+                className="rounded-[14px] border-2 border-line bg-raised p-4"
+                key={guide.name}
+              >
+                <summary className="cursor-pointer text-sm font-extrabold text-ink">
+                  {guide.name}
+                </summary>
+                {guide.note && (
+                  <p className="mt-2 text-sm text-subtle">{guide.note}</p>
+                )}
+                <ol className="mt-3 list-decimal space-y-1.5 pl-5 text-sm text-ink">
+                  {guide.steps.map((step) => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ol>
+              </details>
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="If it stops working">
+          <ul className="list-disc space-y-1.5 pl-5 text-sm text-ink">
+            <li>
+              Check you used the app password rather than your Brock password.
+            </li>
+            <li>
+              App passwords are revoked when someone steps down, so mail apps
+              stop at the same time the portal does.
+            </li>
+            <li>
+              Sending is capped per day, and that cap counts mail sent from any
+              app, not just this one.
+            </li>
+          </ul>
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/app/api/mail/app-passwords/[id]/route.ts
+++ b/app/api/mail/app-passwords/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { notAuthorized } from "@/lib/json";
+import { deleteAppPassword } from "@/lib/mail/stalwart";
+import { ownMailbox } from "../mailbox";
+
+export const DELETE = async (
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) => {
+  const mailbox = await ownMailbox(req);
+  if (!mailbox) return notAuthorized();
+
+  const { id } = await params;
+  await deleteAppPassword(mailbox, id);
+  return new NextResponse(null, { status: 204 });
+};

--- a/app/api/mail/app-passwords/mailbox.ts
+++ b/app/api/mail/app-passwords/mailbox.ts
@@ -1,0 +1,15 @@
+import type { NextRequest } from "next/server";
+import { requireMember } from "@/lib/auth/session";
+import { findSignupByUserId } from "@/lib/db/signups";
+
+/**
+ * The caller's own mailbox name, never one they asked for: these routes act
+ * with the Stalwart admin credential, so the local part cannot come from the
+ * request.
+ */
+export const ownMailbox = async (req: NextRequest): Promise<string | null> => {
+  const user = await requireMember(req);
+  if (!user) return null;
+  const signup = await findSignupByUserId(user.sub);
+  return signup?.username ?? null;
+};

--- a/app/api/mail/app-passwords/route.ts
+++ b/app/api/mail/app-passwords/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { badJson, jsonObject, notAuthorized } from "@/lib/json";
+import { createAppPassword, listAppPasswords } from "@/lib/mail/stalwart";
+import { ownMailbox } from "./mailbox";
+
+const MAX_DESCRIPTION = 60;
+
+export const GET = async (req: NextRequest) => {
+  const mailbox = await ownMailbox(req);
+  if (!mailbox) return notAuthorized();
+  return NextResponse.json(await listAppPasswords(mailbox));
+};
+
+export const POST = async (req: NextRequest) => {
+  const mailbox = await ownMailbox(req);
+  if (!mailbox) return notAuthorized();
+
+  const body = await jsonObject<{ description?: unknown }>(req);
+  if (!body) return badJson();
+  const description =
+    typeof body.description === "string" ? body.description.trim() : "";
+  if (!description || description.length > MAX_DESCRIPTION) {
+    return NextResponse.json(
+      { error: `Name it, in ${MAX_DESCRIPTION} characters or fewer.` },
+      { status: 400 },
+    );
+  }
+
+  const secret = await createAppPassword(mailbox, description);
+  if (!secret) {
+    return NextResponse.json(
+      { error: "The mail server would not create that." },
+      { status: 502 },
+    );
+  }
+  return NextResponse.json({ secret }, { status: 201 });
+};

--- a/lib/mail/provision.ts
+++ b/lib/mail/provision.ts
@@ -6,6 +6,7 @@ import {
   createMailbox,
   localPartTaken,
   makeReadOnly,
+  revokeAppPasswords,
   setExpungeAllowed,
   setGroupMembers,
 } from "./stalwart";
@@ -65,5 +66,6 @@ export const provisionMailbox = async (exec: {
 export const makeMailboxReadOnly = async (username: string): Promise<void> => {
   if (isProtectedMailbox(username)) return;
   await makeReadOnly(username);
+  await revokeAppPasswords(username);
   await deleteApprovedSender(`${username}@${domain()}`);
 };

--- a/lib/mail/stalwart.ts
+++ b/lib/mail/stalwart.ts
@@ -201,3 +201,73 @@ export const clearReadOnly = (localPart: string): Promise<void> =>
 
 export const makeReadOnly = (localPart: string): Promise<void> =>
   setReadOnly(localPart, true);
+
+export type AppPassword = {
+  id: string;
+  description: string;
+  createdAt: string;
+};
+
+export const listAppPasswords = async (
+  localPart: string,
+): Promise<AppPassword[]> => {
+  const account = await accountNamed(localPart);
+  if (!account) return [];
+  const [res] = await jmap<{ list: AppPassword[] }>([
+    ["x:AppPassword/get", { accountId: account.id }, "c0"],
+  ]);
+  return res.list;
+};
+
+/** The secret is returned once, at creation, and never readable again. */
+export const createAppPassword = async (
+  localPart: string,
+  description: string,
+): Promise<string | null> => {
+  const account = await accountNamed(localPart);
+  if (!account) return null;
+  const [res] = await jmap<{ created?: Record<string, { secret: string }> }>([
+    [
+      "x:AppPassword/set",
+      {
+        accountId: account.id,
+        create: {
+          new: {
+            description,
+            permissions: { "@type": "Inherit" },
+            allowedIps: {},
+          },
+        },
+      },
+      "c0",
+    ],
+  ]);
+  return res.created?.new?.secret ?? null;
+};
+
+export const deleteAppPassword = async (
+  localPart: string,
+  id: string,
+): Promise<void> => {
+  const account = await accountNamed(localPart);
+  if (!account) return;
+  await jmap([
+    ["x:AppPassword/set", { accountId: account.id, destroy: [id] }, "c0"],
+  ]);
+};
+
+export const revokeAppPasswords = async (localPart: string): Promise<void> => {
+  const account = await accountNamed(localPart);
+  if (!account) return;
+  const [res] = await jmap<{ list: AppPassword[] }>([
+    ["x:AppPassword/get", { accountId: account.id }, "c0"],
+  ]);
+  if (!res.list.length) return;
+  await jmap([
+    [
+      "x:AppPassword/set",
+      { accountId: account.id, destroy: res.list.map((one) => one.id) },
+      "c0",
+    ],
+  ]);
+};


### PR DESCRIPTION
## What & why

Asked for: instructions under the email tile for setting club mail up in Apple Mail, the Gmail app and Outlook. Writing only instructions would not have worked, and I checked against the live server before building:

- IMAP `mail.brockcsc.ca:993` and submission `:465` are open, TLS, both advertising `AUTH=PLAIN`, and Stalwart already publishes `autoconfig.brockcsc.ca` / `autodiscover.brockcsc.ca`.
- **But all 12 mailboxes have an empty credential set**, and a Keycloak password is rejected over IMAP — `NO [AUTHENTICATIONFAILED]`. The web client only works because it carries an OAuth token, and Apple Mail, the Gmail app and Outlook will not do OAuth against a provider they have never heard of.

So there was no password a member could type into any mail app. This adds one.

**`/admin/mail/setup`**, linked from the mail sidebar:

1. **App passwords** — mint one per device through `x:AppPassword/set`, secret shown once with a copy button, existing ones listed with their created date, revoke on demand.
2. **Server settings** — taken from what the server itself publishes, not from memory.
3. **Per-client steps** — iPhone/iPad, Mac, the Gmail app, Outlook, Thunderbird, and a generic IMAP note.

### Security shape

- The routes act with the **Stalwart admin credential**, so the mailbox is resolved from the caller's own signup record and never from the request. There is no parameter that lets you name someone else's mailbox.
- `makeMailboxReadOnly` now revokes every app password on that mailbox, so a stepped-down exec's mail app stops at the same moment their portal access does. Without that, an app password would quietly outlive the role that justified it.
- No expiry, revocable any time — matching what people expect from a mail client, per the decision on the issue.

## How to test

On the preview, signed in as someone with a mailbox:

1. **Mail → "Set up on your phone"** → create an app password named e.g. `iPhone Mail`. The secret should appear once, with Copy.
2. It should appear in the list below with today's date; **Revoke** should remove it.
3. Prove it actually authenticates, from a terminal:
   ```
   CRED=$(printf '\0you@brockcsc.ca\0<the-app-password>' | base64)
   printf "a1 AUTHENTICATE PLAIN $CRED\na2 LOGOUT\n" | \
     openssl s_client -quiet -connect mail.brockcsc.ca:993 -servername mail.brockcsc.ca
   ```
   Expect `a1 OK ... Authentication successful`.
4. Or just add the account to a real mail app with the settings the page lists.

I verified the whole path on a throwaway mailbox before building: `x:AppPassword/set` returned a secret, IMAP answered `Authentication successful`, and the account was deleted afterwards. `x:AppPassword/get` was verified against a live account (metadata only — the list was empty).

**Note:** mail is a single shared stack, so app passwords created from a preview are real. Revoke anything you make while testing.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `.env.local.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none
- [x] Schema changes have a generated migration — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover` — these use `requireMember`, matching the rest of `/api/mail`, and then narrow to the caller's own mailbox
- [x] Checked in both light and dark themes
- [x] No secrets, internal hostnames or IPs in committed files