### PR TITLE
Write the state the tile move is asking for

### DIFF
--- a/app/api/signups/[id]/consequences.ts
+++ b/app/api/signups/[id]/consequences.ts
@@ -167,18 +167,18 @@ const mailboxItems = (
 
 const tileItems = (exec: Entity<ExecRecord> | null): Item[] => {
   if (!exec) return [];
-  const past = exec.isCurrentExec === false;
+  const toCurrent = exec.isCurrentExec === false;
   return [
     {
-      id: past ? "tile:current" : "tile:past",
+      id: toCurrent ? "tile:current" : "tile:past",
       group: "tile",
-      title: past
+      title: toCurrent
         ? "Move their tile back to the current team"
         : "Move their tile to past executives",
-      detail: past
+      detail: toCurrent
         ? "They appear again under the current executive team."
         : "They drop off the current team and appear under past executives.",
-      run: () => update(execsTable, exec.id, { isCurrentExec: !past }),
+      run: () => update(execsTable, exec.id, { isCurrentExec: toCurrent }),
     },
   ];
 };


### PR DESCRIPTION
## What & why

Moving an executive to alumni through the admin portal changed their roles and mailbox, reported success — and left their tile on the current team.

The tile consequence in `app/api/signups/[id]/consequences.ts` computed `past` from the tile's *current* state and then wrote `isCurrentExec: !past`, which is the value it already held:

- current exec (`past === false`) → the offered action is "Move their tile to past executives" → it wrote `isCurrentExec: true`. No change.
- past exec (`past === true`) → the offered action is "Move their tile back to the current team" → it wrote `isCurrentExec: false`. No change.

So both directions were no-op writes. Nothing threw, so `applyConsequences` counted the item as applied and the UI reported success. Nothing was rehearsed here either — `rehearsed()` deliberately exempts the `tile` group, and this runs in production where `ownsIdentities()` is true. The role half was working the whole time; only the tile write was inert.

Confirmed against production read-only: an affected tile still reads `isCurrentExec: true` while the matching Keycloak account has lost `executive` and gained `alumni`. Roles moved, tile did not — exactly what a no-op tile write produces.

The fix renames the flag to `toCurrent`, the state the action moves the tile *to*, so the id, the title, the detail and the write all read off one value. Nothing else changes; `transitionFor` already picked the right consequence id.

`signups.isFormerExec` is not part of this — it records how someone described themselves on the sign-up form, not their present standing.

### Existing records need a one-off correction

The code fix does not repair writes that never happened. Anyone moved before this lands still has a tile pointing the wrong way. Once this is merged, re-run the move on them with only the tile consequence ticked — the role and mailbox halves already took effect — and the tile will follow. No data migration is needed.

## How to test

On the branch's preview, signed in as a co-president:

1. Admin → People, open a current executive who has a tile. Preview shares the live Keycloak realm, so role and mailbox effects are rehearsed there rather than written; tile changes are real, which is what we want to observe.
2. Under "Executive status", press "Move to former executive...", untick everything except "Move their tile to past executives", and Apply.
3. The header picks up the "Past" pill and the panel now offers "Return to the current team". Before this change the panel still said "Move to former executive" afterwards, because nothing had been written.
4. Load `/team` — they appear under past executives rather than the current team.
5. Press "Return to the current team...", apply the tile item only, and confirm both the admin view and `/team` put them back. Both directions were broken; both should work now.

Filtering by Current/Past in Admin → People is another quick way to see the tile actually moved.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `.env.local.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none
- [x] Schema changes have a generated migration — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover` — unchanged; `/api/signups/[id]/apply` still requires an approver
- [x] Checked in both light and dark themes — no visual change
- [x] No secrets, internal hostnames or IPs in committed files