### PR TITLE
Serve a certificate mail apps will accept

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,14 @@ Send limits (`lib/mail/limit.ts`) count the Sent mailbox since local midnight vi
 `POST /api/mail/send` returns **429**. Caps per message: 100 KB text, 400 KB HTML, 20 attachments,
 50 recipients, 15 MB per uploaded file.
 
+**TLS.** Stalwart serves its own self-signed certificate unless given one, which mail apps either
+refuse outright or warn about. Traefik already holds a Let's Encrypt wildcard for `*.brockcsc.ca`
+(Cloudflare DNS-01, stored under `le-dns` in `acme-dns.json`), so `deploy/mail/refresh-cert.sh` copies
+it into Stalwart through `x:Certificate/set` and restarts the container when the expiry changes. It is
+idempotent, so run it as often as you like. Install it on the VPS beside `drop-db.sh` and give it a
+daily timer - nothing runs it automatically from this repo, and the certificate goes stale roughly
+every sixty days without it.
+
 **Outside mail apps.** Keycloak passwords do not authenticate against Stalwart, so IMAP and SMTP need
 a Stalwart app password. `/admin/mail/setup` lets a member mint one per device and revoke it, through
 `x:AppPassword/set` in `lib/mail/stalwart.ts`; the secret is returned once and never readable again.

--- a/deploy/mail/refresh-cert.sh
+++ b/deploy/mail/refresh-cert.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -eu
+
+ACME_JSON="${ACME_JSON:-/var/lib/docker/volumes/wayfarer_traefik-acme/_data/acme-dns.json}"
+ACME_RESOLVER="${ACME_RESOLVER:-le-dns}"
+CERT_DOMAIN="${CERT_DOMAIN:-*.brockcsc.ca}"
+CONTAINER="${STALWART_CONTAINER:-brockcsc-stalwart}"
+STALWART_URL="${STALWART_URL:-http://brockcsc-stalwart:8080}"
+NETWORK="${DOCKER_NETWORK:-wayfarer-net}"
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+jq -r --arg r "$ACME_RESOLVER" --arg d "$CERT_DOMAIN" \
+  '.[$r].Certificates[] | select(.domain.main == $d) | .certificate' \
+  "$ACME_JSON" | base64 -d > "$work/cert.pem"
+jq -r --arg r "$ACME_RESOLVER" --arg d "$CERT_DOMAIN" \
+  '.[$r].Certificates[] | select(.domain.main == $d) | .key' \
+  "$ACME_JSON" | base64 -d > "$work/key.pem"
+
+[ -s "$work/cert.pem" ] && [ -s "$work/key.pem" ] || {
+  echo "no certificate for $CERT_DOMAIN in $ACME_JSON" >&2
+  exit 1
+}
+
+expires=$(openssl x509 -in "$work/cert.pem" -noout -enddate | cut -d= -f2)
+expires=$(date -u -d "$expires" +%Y-%m-%dT%H:%M:%SZ)
+
+admin=$(docker exec "$CONTAINER" printenv STALWART_RECOVERY_ADMIN)
+
+jmap() {
+  docker run --rm --network "$NETWORK" -v "$1:/payload.json:ro" \
+    curlimages/curl:latest -s -u "$admin" \
+    -H "content-type: application/json" \
+    --data-binary @/payload.json "$STALWART_URL/jmap"
+}
+
+jq -n '{using:["urn:ietf:params:jmap:core","urn:stalwart:jmap"],
+        methodCalls:[["x:Certificate/get",{},"c0"]]}' > "$work/get.json"
+current=$(jmap "$work/get.json")
+
+installed=$(echo "$current" | jq -r --arg d "$CERT_DOMAIN" \
+  '[.methodResponses[0][1].list[] | select(.subjectAlternativeNames | has($d))][0] // empty')
+
+if [ -n "$installed" ] &&
+   [ "$(echo "$installed" | jq -r .notValidAfter)" = "$expires" ]; then
+  echo "up to date, expires $expires"
+  exit 0
+fi
+
+id=$(echo "$installed" | jq -r '.id // empty')
+if [ -n "$id" ]; then
+  jq -n --rawfile cert "$work/cert.pem" --rawfile key "$work/key.pem" --arg id "$id" \
+    '{using:["urn:ietf:params:jmap:core","urn:stalwart:jmap"],
+      methodCalls:[["x:Certificate/set",{update:{($id):{
+        certificate:{"@type":"Text",value:$cert},
+        privateKey:{"@type":"Text",secret:$key}}}},"c0"]]}' > "$work/set.json"
+else
+  jq -n --rawfile cert "$work/cert.pem" --rawfile key "$work/key.pem" \
+    '{using:["urn:ietf:params:jmap:core","urn:stalwart:jmap"],
+      methodCalls:[["x:Certificate/set",{create:{new:{
+        certificate:{"@type":"Text",value:$cert},
+        privateKey:{"@type":"Text",secret:$key}}}},"c0"]]}' > "$work/set.json"
+fi
+
+result=$(jmap "$work/set.json")
+echo "$result" | jq -e '.methodResponses[0][1] | (.created // .updated)' >/dev/null || {
+  echo "stalwart rejected the certificate: $result" >&2
+  exit 1
+}
+
+docker restart "$CONTAINER" >/dev/null
+echo "installed certificate expiring $expires and restarted $CONTAINER"


### PR DESCRIPTION
## What & why

Connecting a real mail app to the club mailbox warned about an untrusted certificate in Apple Mail, and simply failed in the Gmail app. Both are the same cause:

```
$ openssl s_client -connect mail.brockcsc.ca:993 -servername mail.brockcsc.ca
subject=/CN=rcgen self signed cert
Verify return code: 18 (self signed certificate)
```

Stalwart had never been given a certificate, so it was serving the self-signed one it generates for itself. Apple Mail offers you a "trust anyway" prompt; the Gmail app has no such override and just refuses to connect.

The certificate already existed on the machine — Traefik holds a Let's Encrypt **wildcard for `*.brockcsc.ca`** (Cloudflare DNS-01, stored under the `le-dns` resolver), which covers `mail.brockcsc.ca`. It was only ever on the wrong side of the box.

`deploy/mail/refresh-cert.sh` copies it into Stalwart via `x:Certificate/set` and restarts the container when the expiry has moved. It is idempotent — the common case prints `up to date` and exits 0.

**This is already applied in production**, so the warning is gone right now:

| Port | Before | After |
|---|---|---|
| 993 IMAP | self-signed, `Verify return code: 18` | **`Verify return code: 0 (ok)`** |
| 465 submission | self-signed | **`0 (ok)`** |
| 25 SMTP (STARTTLS) | self-signed | **`0 (ok)`** |

Port 25 matters beyond mail apps: other mail servers negotiate STARTTLS there, and a verifiable certificate is what MTA-STS and DANE want to see.

### Why a host script rather than a container

Stalwart cannot fetch its own certificate here: Let's Encrypt's HTTP-01 lands on `/.well-known/acme-challenge/`, which Traefik intercepts for its own ACME, and TLS-ALPN-01 needs port 443, which Traefik owns. Copying Traefik's wildcard is the path with the fewest moving parts. The script needs the Docker socket to restart Stalwart, so it lives on the host beside `drop-db.sh` and `ssh-dispatch.sh` — the same pattern this repo already uses for things that must run there.

## How to test

Nothing to click. From anywhere:

```
echo | openssl s_client -connect mail.brockcsc.ca:993 -servername mail.brockcsc.ca 2>&1 | grep "Verify return"
```

Expect `Verify return code: 0 (ok)`. Then add the account to Apple Mail or the Gmail app using `/admin/mail/setup` — neither should complain now.

I tested the script both ways on the VPS: with the certificate in place it printed `up to date, expires 2026-11-11T02:57:17Z` and made no change; with it removed it installed and restarted, and 993 and 465 came back `0 (ok)`.

## Needed after merging

Install it on the VPS and give it a daily timer — **nothing in this repo runs it**, and the certificate goes stale roughly every sixty days when Traefik renews:

```
sudo install -m 755 deploy/mail/refresh-cert.sh /opt/wayfarer/brockcsc/refresh-cert.sh
# then a daily systemd timer or cron entry calling it
```

## Also noticed, not fixed here

Stalwart's autoconfig advertises **POP3 on 995**, but only 25, 465 and 993 are published, so any client that picks POP will fail. `/admin/mail/setup` steers people to IMAP and never mentions POP, so nobody following our own instructions hits it. Worth either publishing 995 or trimming the autoconfig.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `.env.local.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none; the script reads the admin credential from the running container
- [x] Schema changes have a generated migration — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover` — no route changes
- [x] Checked in both light and dark themes — no UI change
- [x] No secrets, internal hostnames or IPs in committed files — paths and volume names only, matching the existing deploy scripts