### PR TITLE
Move to the Node 24 LTS line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 22
+          node-version: 24
       - run: npm audit --omit=dev --audit-level=high
 
   dependency-review:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Everything technical lives here. The [README](README.md) is user-facing only.
 
 ## Prerequisites
 
-- **Node 22.9+** — the dev scripts use `node --env-file-if-exists`
+- **Node 24+** — the dev scripts use `node --env-file-if-exists`
 - **Docker** — for the local Postgres only
 - A Keycloak account in the `brockcsc` realm, if you need the admin portal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:22-alpine AS deps
+FROM node:24-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/app/admin/mail/setup/clients.ts
+++ b/app/admin/mail/setup/clients.ts
@@ -4,7 +4,7 @@ export type ClientGuide = {
   steps: string[];
 };
 
-export const MAIL_HOST = "mail.brockcsc.ca";
+const MAIL_HOST = "mail.brockcsc.ca";
 
 export const SERVER_SETTINGS = [
   { label: "Incoming (IMAP)", value: `${MAIL_HOST}, port 993, SSL/TLS` },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/jsonwebtoken": "^9.0.7",
-        "@types/node": "^20",
+        "@types/node": "^24",
         "@types/pg": "^8.21.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3221,12 +3221,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/opossum": {
@@ -10028,9 +10028,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/jsonwebtoken": "^9.0.7",
-    "@types/node": "^20",
+    "@types/node": "^24",
     "@types/pg": "^8.21.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## What & why

Closes #81 and #88, which were asking the right question with the wrong answer.

**Node 22 reaches end of life around October 2026** — about two months away — so staying put was not an option. Dependabot proposed **26**, but 26 is still *Current* and only becomes Active LTS in October 2026. Putting the production runtime on Current means tracking a line that has not settled.

**Node 24 (Krypton)** has been Active LTS since November 2025 and is supported to roughly November 2027. Same headroom, none of the wait.

The three places that name a Node version had drifted apart, which is how #88 came to propose `@types/node@26` against a Node 22 runtime — types describing APIs that would not exist at runtime:

| | Before | After |
|---|---|---|
| `Dockerfile` (all three stages) | 22-alpine | **24-alpine** |
| `ci.yml` `node-version` | 22 | **24** |
| `@types/node` | ^20 | **^24** |
| CONTRIBUTING prerequisite | Node 22.9+ | **Node 24+** |

Also un-exports `MAIL_HOST`, which had no consumer outside its own file — knip flagged it once everything else was clean.

## How to test

Mostly CI's job, but the thing worth confirming is that the native modules still work, since the image carries two of them:

1. `build-image` on this PR builds the whole Dockerfile on `node:24-alpine` — that is the real test.
2. On the preview, **Mail → Set up on your phone**, then upload a photo in Admin → Profile. That exercises `sharp` and `heic-decode`, which are the only compiled dependencies here.

I checked the native modules directly against `node:24-alpine` before opening this:

```
node24-alpine: sharp 0.35.3 heic-decode ok, webp 80 bytes
```

Locally, `lint`, `typecheck`, `format:check`, `build` and `deadcode` all pass on 24.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `.env.local.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none
- [x] Schema changes have a generated migration — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover` — no route changes
- [x] Checked in both light and dark themes — no UI change
- [x] No secrets, internal hostnames or IPs in committed files