### PR TITLE
Read the Komodo server from a repository variable

### DIFF
--- a/.github/workflows/deploy-mail.yml
+++ b/.github/workflows/deploy-mail.yml
@@ -57,13 +57,14 @@ jobs:
           KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
           KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
           STACK_NAME: brockcsc-mail
+          KOMODO_SERVER: ${{ vars.KOMODO_SERVER }}
         run: |
           source .github/scripts/komodo.sh
 
           # auto_pull, unlike the app stack: these are upstream images, not ones
           # this repo builds, so a redeploy is how they pick up a new tag.
           config=$(jq -n '{
-            server: "wayfarerbx-vps",
+            server: env.KOMODO_SERVER,
             repo: "BrockCSC/website",
             branch: "main",
             git_provider: "github.com",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,13 +163,14 @@ jobs:
           KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
           KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
           STACK_NAME: ${{ steps.deploy-context.outputs.stack-name }}
+          KOMODO_SERVER: ${{ vars.KOMODO_SERVER }}
           BRANCH: ${{ steps.deploy-context.outputs.branch }}
           ENVIRONMENT: ${{ steps.deploy-context.outputs.environment }}
         run: |
           source .github/scripts/komodo.sh
 
           config=$(jq -n --arg branch "$BRANCH" --arg environment "$ENVIRONMENT" '{
-            server: "wayfarerbx-vps",
+            server: env.KOMODO_SERVER,
             repo: "BrockCSC/website",
             branch: $branch,
             git_provider: "github.com",


### PR DESCRIPTION
## What & why

The Komodo server resource was renamed to **`brockcsc-vps`**. Both deploy workflows carried the old name inline:

- `.github/workflows/deploy.yml` — every app deploy
- `.github/workflows/deploy-mail.yml` — the mail stack

Each sends `server: "wayfarerbx-vps"` in its `CreateStack` / `UpdateStack` call, so Komodo would be asked for a server that no longer exists and **every deploy would fail** — app and mail alike. Running containers are unaffected, since Komodo links stacks by id rather than name; only our configuration-by-name calls break.

Confirmed against Komodo's own database rather than guessing:

```
db.getSiblingDB("komodo").Server.find({}, {name:1})
→ [ { name: 'brockcsc-vps' } ]
```

Both now read `vars.KOMODO_SERVER`, which I have already set to `brockcsc-vps` on the repository. The next rename is a settings change rather than a commit, matching how `KOMODO_HOST` and `VPS_HOST` are already handled.

Nothing else in the repo referenced the old name — `ensure-action` and `komodo/actions/preview-sweep.ts` address resources by their own names, and the SSH deploy path uses a separate host alias.

## How to test

This PR's own preview deploy is the test: `deploy-stack` reaching Komodo and bringing the stack up means the name resolves. A failure would show as Komodo rejecting the stack config.

## Checklist

- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` pass
- [x] `npm run build` passes
- [x] New env vars added to `.env.example`, `.env.local.example`, `deploy/docker-compose.yml` and `komodo/deploy-context.mjs` — none; `KOMODO_SERVER` is a repository variable, already set
- [x] Schema changes have a generated migration — none
- [x] Admin-only routes are gated with `requireAdmin` / `requireApprover` — no route changes
- [x] Checked in both light and dark themes — no UI change
- [x] No secrets, internal hostnames or IPs in committed files